### PR TITLE
Add 7 special tiles

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,6 +1,17 @@
 const gridSize = 30;
 const container = document.getElementById('game-container');
 
+// Definition for the 7 core tiles of truth
+const TILE_TYPES = {
+  EMBER: { name: 'Ember of Compounding', symbol: '∞', class: 'tile-ember' },
+  ECHO: { name: 'Echo of Silence', symbol: 'Ψ', class: 'tile-echo' },
+  LENS: { name: 'Lens of Attention', symbol: '👁️', class: 'tile-lens' },
+  MIRROR: { name: 'Mirror of Bias', symbol: '🔍', class: 'tile-mirror' },
+  MARK: { name: 'Questioner\u2019s Mark', symbol: '❓', class: 'tile-mark' },
+  MAPLESS: { name: 'Mapless Path', symbol: '🗺️✖️', class: 'tile-mapless' },
+  STONE: { name: 'Stone of Momentum', symbol: '⚙️', class: 'tile-stone' },
+};
+
 let grid = [];
 let playerPos = { x: 1, y: 1 };
 
@@ -28,12 +39,45 @@ for (let y = 0; y < gridSize; y++) {
   grid.push(row);
 }
 
+placeSpecialTiles();
+
+function placeSpecialTiles() {
+  const cells = Array.from(container.children);
+  for (const [key, tile] of Object.entries(TILE_TYPES)) {
+    const count = 1 + Math.floor(Math.random() * 2); // 1 or 2 of each
+    for (let i = 0; i < count; i++) {
+      let placed = false;
+      while (!placed) {
+        const x = Math.floor(Math.random() * gridSize);
+        const y = Math.floor(Math.random() * gridSize);
+        if (grid[y][x] === 'ground' && !(x === playerPos.x && y === playerPos.y)) {
+          grid[y][x] = key;
+          const index = y * gridSize + x;
+          const cell = cells[index];
+          cell.classList.add('special-tile', tile.class);
+          cell.dataset.symbol = tile.symbol;
+          cell.title = tile.name;
+          placed = true;
+        }
+      }
+    }
+  }
+}
+
 function drawPlayer() {
   document.querySelectorAll('.cell').forEach(cell => cell.classList.remove('player'));
   const index = playerPos.y * gridSize + playerPos.x;
   container.children[index].classList.add('player');
 }
 drawPlayer();
+function checkSpecialTile() {
+  const key = grid[playerPos.y][playerPos.x];
+  const tile = TILE_TYPES[key];
+  if (tile) {
+    console.log(`${tile.name} activated`);
+  }
+}
+
 
 // A* Pathfinding
 function heuristic(a, b) {
@@ -103,5 +147,6 @@ function moveAlongPath(path) {
   const next = path.shift();
   playerPos = next;
   drawPlayer();
+  checkSpecialTile();
   setTimeout(() => moveAlongPath(path), 60);
 }

--- a/style.css
+++ b/style.css
@@ -46,3 +46,19 @@ body {
   border-radius: 50%;
 }
 
+.special-tile {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.2vw;
+  color: #fff;
+}
+
+.tile-ember { background-color: #c0392b; }
+.tile-echo { background-color: #8e44ad; }
+.tile-lens { background-color: #2980b9; }
+.tile-mirror { background-color: #f1c40f; color: #000; }
+.tile-mark { background-color: #e67e22; }
+.tile-mapless { background-color: #7f8c8d; }
+.tile-stone { background-color: #27ae60; }
+


### PR DESCRIPTION
## Summary
- define 7 core tiles with names, symbols and css classes
- randomly place each tile on the grid avoiding player start and walls
- display icons via CSS classes and log activation when stepped on

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685ab2fd93f483318396b6c10693093f