### PR TITLE
Add core truth tiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,17 @@ A simple 30×30 grid-based pathfinding game using HTML, CSS, and JavaScript. No 
 - Impassable wall tiles
 - Smooth animation
 
+### Core Truth Tiles
+The game includes 7 symbolic tiles representing deep ideas:
+
+- **∞ Ember of Compounding** – Growth from consistency
+- **Ψ Echo of Silence** – The power of quiet
+- **👁️ Lens of Attention** – You become what you attend to
+- **🔍 Mirror of Bias** – See through your mental filters
+- **❓ Questioner's Mark** – Ask better, get better
+- **🗺️✖️ Mapless Path** – Trust intuition over the map
+- **⚙️ Stone of Momentum** – Action fuels motivation
+
 ### How to Play
 1. Open `index.html` in a browser.
 2. Click/tap any ground tile — the white player will move toward it.

--- a/style.css
+++ b/style.css
@@ -45,20 +45,23 @@ body {
   background: white;
   border-radius: 50%;
 }
-
-.special-tile {
+/* Truth Tile Base Style */
+.cell.truth {
+  font-size: 0.75rem;
+  text-align: center;
+  color: white;
   display: flex;
-  align-items: center;
   justify-content: center;
-  font-size: 1.2vw;
-  color: #fff;
+  align-items: center;
+  font-family: system-ui, sans-serif;
+  font-weight: bold;
 }
 
-.tile-ember { background-color: #c0392b; }
-.tile-echo { background-color: #8e44ad; }
+/* Individual Tile Themes */
+.tile-ember { background-color: #d35400; }
+.tile-echo { background-color: #2c3e50; }
 .tile-lens { background-color: #2980b9; }
-.tile-mirror { background-color: #f1c40f; color: #000; }
-.tile-mark { background-color: #e67e22; }
+.tile-mirror { background-color: #8e44ad; }
+.tile-mark { background-color: #27ae60; }
 .tile-mapless { background-color: #7f8c8d; }
-.tile-stone { background-color: #27ae60; }
-
+.tile-stone { background-color: #f39c12; }


### PR DESCRIPTION
## Summary
- style truth tile display and theme colors
- generate special tiles during grid creation
- log when stepping on a special tile
- document the seven truth tiles

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685ab4c19c308331b93961c929c3ccbb