### PR TITLE
Add mobile stylesheet with responsive adjustments

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Grid Game</title>
   <link rel="stylesheet" href="style.css" />
+  <link rel="stylesheet" href="mobile.css" media="(max-width: 768px)" />
   <link rel="icon" href="assets/labyrinth-icon.svg" type="image/svg+xml" />
 </head>
 <body>

--- a/mobile.css
+++ b/mobile.css
@@ -1,0 +1,41 @@
+/* === Mobile Overrides === */
+
+/* Smaller cells, less padding */
+#game-container {
+  grid-template-columns: repeat(30, 10vw);
+  grid-template-rows: repeat(30, 10vw);
+  gap: 1vw;
+}
+
+/* Scale text and icons down slightly */
+.cell {
+  font-size: 0.85rem;
+}
+
+/* Truth tile tweaks for legibility */
+.truth {
+  font-size: 0.9rem;
+  text-shadow: none;
+}
+
+/* Player/NPC smaller circles */
+.player::after,
+.npc::after {
+  top: 20%;
+  left: 20%;
+  width: 60%;
+  height: 60%;
+}
+
+/* Dialogue box mobile adjustment */
+.dialogue-box {
+  bottom: 5%;
+  padding: 14px;
+  font-size: 0.85rem;
+  max-width: 95vw;
+}
+
+.dialogue-box button {
+  font-size: 0.85rem;
+  padding: 5px 10px;
+}


### PR DESCRIPTION
## Summary
- add `mobile.css` with smartphone-specific overrides
- load the new stylesheet in `index.html` only for small screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685acfbb19e48331a9f29673e1f3c91c