### PR TITLE
Add Japanese learning course

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,5 +15,6 @@
   </div>
   <div id="game-container"></div>
   <script src="script.js"></script>
+  <script src="lessons/japanese.js"></script>
 </body>
 </html>

--- a/lessons/japanese.js
+++ b/lessons/japanese.js
@@ -1,0 +1,66 @@
+const japaneseLessons = [
+  {
+    title: "Lesson 1: Introduction to Japanese",
+    content: `
+      <p>Japanese has three writing systems:</p>
+      <ul>
+        <li><strong>Hiragana (ひらがな)</strong> – phonetic, native words</li>
+        <li><strong>Katakana (カタカナ)</strong> – phonetic, foreign words</li>
+        <li><strong>Kanji (漢字)</strong> – logographic, Chinese characters</li>
+      </ul>
+    `,
+    quiz: {
+      question: "Which system is used for native Japanese words?",
+      options: ["Katakana", "Kanji", "Hiragana"],
+      answer: "Hiragana"
+    }
+  },
+  {
+    title: "Lesson 2: Hiragana Basics",
+    content: `
+      <p>Here are the five basic vowel sounds in Hiragana:</p>
+      <p>あ (a), い (i), う (u), え (e), お (o)</p>
+    `,
+    quiz: {
+      question: "Which of these is the Hiragana for 'e'?",
+      options: ["あ", "え", "お"],
+      answer: "え"
+    }
+  }
+];
+
+function loadJapaneseLesson(index) {
+  const course = document.getElementById('course-container');
+  const lesson = japaneseLessons[index];
+
+  course.innerHTML = `
+    <div class="dialogue-box" style="max-height: 90vh; overflow-y: auto;">
+      <h2>${lesson.title}</h2>
+      ${lesson.content}
+      <p><strong>${lesson.quiz.question}</strong></p>
+      ${lesson.quiz.options.map(opt => `
+        <button onclick="checkAnswer('${opt}', '${lesson.quiz.answer}', ${index})">${opt}</button>
+      `).join('')}
+      <br><br>
+      <button onclick="exitCourse()">Leave Course</button>
+    </div>
+  `;
+}
+
+function checkAnswer(selected, correct, index) {
+  const course = document.getElementById('course-container');
+  const message = selected === correct
+    ? "<p style='color:lime'>✅ Correct!</p>"
+    : "<p style='color:orangered'>❌ Try again.</p>";
+
+  course.querySelector(".dialogue-box").insertAdjacentHTML('beforeend', message);
+
+  if (selected === correct && japaneseLessons[index + 1]) {
+    setTimeout(() => loadJapaneseLesson(index + 1), 1000);
+  }
+}
+
+function exitCourse() {
+  const course = document.getElementById('course-container');
+  if (course) course.remove();
+}

--- a/script.js
+++ b/script.js
@@ -172,22 +172,23 @@ function glossarionMore() {
 function glossarionTopic(topic) {
   clearDialogue();
 
-  const box = document.createElement('div');
-  box.className = 'dialogue-box';
-
-  let content = '';
   if (topic === 'japanese') {
-    content = `“Ah, Japanese... where sound meets subtlety. A language of layers, where silence holds grammar.”`;
+    startJapaneseCourse();
   } else if (topic === 'russian') {
-    content = `“Russian... a structure of strength. Its words are bricks, its grammar—a cathedral.”`;
+    // Future placeholder
+    alert("Russian course coming soon.");
   }
+}
 
-  box.innerHTML = `
-    <p><strong>Glossarion:</strong> ${content}</p>
-    <button onclick="closeDialogue()">Leave</button>
-  `;
+function startJapaneseCourse() {
+  clearDialogue();
 
-  document.body.appendChild(box);
+  const course = document.createElement('div');
+  course.id = 'course-container';
+  document.body.appendChild(course);
+
+  // Load lesson 1
+  loadJapaneseLesson(0);
 }
 
 function clearDialogue() {

--- a/style.css
+++ b/style.css
@@ -122,3 +122,17 @@ body {
   border-radius: 4px;
   font-family: inherit;
 }
+
+#course-container {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background: rgba(10, 10, 10, 0.95);
+  z-index: 10000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+}


### PR DESCRIPTION
## Summary
- hook Glossarion into the new Japanese course
- create `startJapaneseCourse()` loader
- add lessons script with simple quizzes
- style `#course-container` overlay
- include Japanese course script in `index.html`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685ad6988bd48331af213c69e838320d