### PR TITLE
Implement wisdom point system

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
   <link rel="icon" href="assets/labyrinth-icon.svg" type="image/svg+xml" />
 </head>
 <body>
+  <div id="wisdom-hud">🧠 WP: <span id="wp-count">0</span></div>
   <!-- Game icon display -->
   <div style="margin-bottom: 20px; text-align: center;">
     <img src="assets/labyrinth-icon.svg" alt="Labyrinth Icon" width="80" height="80">

--- a/lessons/japanese.js
+++ b/lessons/japanese.js
@@ -55,8 +55,16 @@ function checkAnswer(selected, correct, index) {
 
   course.querySelector(".dialogue-box").insertAdjacentHTML('beforeend', message);
 
-  if (selected === correct && japaneseLessons[index + 1]) {
-    setTimeout(() => loadJapaneseLesson(index + 1), 1000);
+  if (selected === correct) {
+    const key = `jp_lesson_${index}_done`;
+    if (!localStorage.getItem(key)) {
+      localStorage.setItem(key, 'true');
+      if (typeof gainWisdom === 'function') gainWisdom(1);
+    }
+
+    if (japaneseLessons[index + 1]) {
+      setTimeout(() => loadJapaneseLesson(index + 1), 1000);
+    }
   }
 }
 

--- a/script.js
+++ b/script.js
@@ -3,6 +3,13 @@ let grid = [];
 let playerPos = { x: 1, y: 1 }; // starting point
 const container = document.getElementById('game-container');
 
+// === Wisdom Point System ===
+let wisdomPoints = 0;
+// Load saved value
+if (localStorage.getItem('wp')) {
+  wisdomPoints = parseInt(localStorage.getItem('wp'), 10);
+}
+
 const TILE_TYPES = {
   GROUND: { symbol: "", class: "ground" },
   NPC:    { symbol: "", class: "npc" }
@@ -166,6 +173,12 @@ function glossarionMore() {
     <button onclick="closeDialogue()">Leave</button>
   `;
 
+  if (localStorage.getItem('jp_lesson_0_done') && localStorage.getItem('jp_lesson_1_done')) {
+    box.innerHTML += `
+      <p><em>“Ah… you have begun the path of the language. It has changed you.”</em></p>
+    `;
+  }
+
   document.body.appendChild(box);
 }
 
@@ -200,3 +213,18 @@ function closeDialogue() {
   const box = document.querySelector('.dialogue-box');
   if (box) box.remove();
 }
+
+// ===== Wisdom Point Helpers =====
+function gainWisdom(amount) {
+  wisdomPoints += amount;
+  localStorage.setItem('wp', wisdomPoints);
+  updateWisdomHUD();
+}
+
+function updateWisdomHUD() {
+  const el = document.getElementById('wp-count');
+  if (el) el.textContent = wisdomPoints;
+}
+
+// Initialize HUD display on load
+updateWisdomHUD();

--- a/style.css
+++ b/style.css
@@ -136,3 +136,18 @@ body {
   justify-content: center;
   padding: 1rem;
 }
+
+/* Wisdom HUD */
+#wisdom-hud {
+  position: fixed;
+  top: 10px;
+  left: 10px;
+  color: #fff;
+  font-family: 'Segoe UI', sans-serif;
+  background: rgba(0, 0, 0, 0.7);
+  padding: 8px 12px;
+  border-radius: 6px;
+  font-size: 1rem;
+  z-index: 2000;
+  border: 1px solid #27ae60;
+}


### PR DESCRIPTION
## Summary
- display player's Wisdom Points HUD
- save and update WP in `script.js`
- add WP tracking in Japanese lessons
- show special Glossarion line after completing lessons

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_685ad8d2c4848331ad25fd276ffe8c20