### PR TITLE
Enhance mobile dialogue layout

### DIFF
--- a/mobile.css
+++ b/mobile.css
@@ -27,15 +27,45 @@
   height: 60%;
 }
 
-/* Dialogue box mobile adjustment */
+/* === Mobile Dialogue Overrides === */
 .dialogue-box {
-  bottom: 5%;
-  padding: 14px;
-  font-size: 0.85rem;
-  max-width: 95vw;
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 92vw;
+  max-height: 80vh;
+  overflow-y: auto;
+  padding: 20px;
+  background: rgba(20, 20, 20, 0.95);
+  border: 2px solid #27ae60;
+  border-radius: 10px;
+  color: white;
+  font-size: 1rem;
+  line-height: 1.5;
+  z-index: 1000;
+  box-shadow: 0 0 15px rgba(39, 174, 96, 0.6);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
 }
 
+/* Make buttons large and touch-friendly */
 .dialogue-box button {
-  font-size: 0.85rem;
-  padding: 5px 10px;
+  font-size: 1rem;
+  padding: 10px 18px;
+  margin-top: 12px;
+  border-radius: 6px;
+  background: #27ae60;
+  color: white;
+  border: none;
+  cursor: pointer;
+  width: 90%;
+  max-width: 300px;
+  transition: background 0.3s ease;
+}
+
+.dialogue-box button:hover {
+  background: #219150;
 }


### PR DESCRIPTION
## Summary
- center the dialogue on small screens and increase its size
- tweak button styles for touch devices

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685adb85a3e883318f578512647bbe5b