### PR TITLE
Fix mobile dialogue layout

### DIFF
--- a/mobile.css
+++ b/mobile.css
@@ -28,44 +28,26 @@
 }
 
 /* === Mobile Dialogue Overrides === */
-.dialogue-box {
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  width: 92vw;
-  max-height: 80vh;
-  overflow-y: auto;
-  padding: 20px;
-  background: rgba(20, 20, 20, 0.95);
-  border: 2px solid #27ae60;
-  border-radius: 10px;
-  color: white;
-  font-size: 1rem;
-  line-height: 1.5;
-  z-index: 1000;
-  box-shadow: 0 0 15px rgba(39, 174, 96, 0.6);
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  text-align: center;
-}
+@media (max-width: 768px) {
+  .dialogue-box {
+    top: 50% !important;
+    left: 50% !important;
+    bottom: auto !important;
+    transform: translate(-50%, -50%) !important;
+    width: 90vw !important;
+    max-height: 80vh;
+    overflow-y: auto;
+    padding: 24px;
+    font-size: 1.05rem;
+    text-align: center;
+    border-radius: 10px;
+    box-shadow: 0 0 20px rgba(39, 174, 96, 0.6);
+  }
 
-/* Make buttons large and touch-friendly */
-.dialogue-box button {
-  font-size: 1rem;
-  padding: 10px 18px;
-  margin-top: 12px;
-  border-radius: 6px;
-  background: #27ae60;
-  color: white;
-  border: none;
-  cursor: pointer;
-  width: 90%;
-  max-width: 300px;
-  transition: background 0.3s ease;
-}
-
-.dialogue-box button:hover {
-  background: #219150;
+  .dialogue-box button {
+    font-size: 1rem;
+    width: 100%;
+    margin: 10px 0;
+    padding: 12px;
+  }
 }

--- a/style.css
+++ b/style.css
@@ -98,18 +98,17 @@ body {
   bottom: 10%;
   left: 50%;
   transform: translateX(-50%);
-  background: #222;
-  color: #fff;
-  padding: 16px;
+  width: auto;
+  max-width: 90vw;
+  background: rgba(20, 20, 20, 0.95);
   border: 2px solid #27ae60;
+  color: #fff;
+  padding: 16px 20px;
   border-radius: 8px;
-  max-width: 90%;
-  max-height: 40vh;
-  overflow-y: auto;
-  font-family: "Segoe UI", sans-serif;
-  font-size: 0.95rem;
-  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.6);
   z-index: 1000;
+  box-shadow: 0 0 10px rgba(39, 174, 96, 0.5);
+  font-size: 0.95rem;
+  transition: all 0.3s ease;
 }
 
 .dialogue-box button {


### PR DESCRIPTION
## Summary
- adjust main dialogue box styles for easier mobile override
- override dialogue box position and layout within mobile.css

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685ade23dd708331a129e8b134f53d8a