### PR TITLE
Add Japanese Learning Hub

### DIFF
--- a/lessons/japanese.js
+++ b/lessons/japanese.js
@@ -208,4 +208,6 @@ function checkAnswer(selected, correct, index) {
 function exitCourse() {
   const course = document.getElementById('course-container');
   if (course) course.remove();
+  const hub = document.getElementById('course-hub');
+  if (hub) hub.remove();
 }

--- a/script.js
+++ b/script.js
@@ -196,12 +196,28 @@ function glossarionTopic(topic) {
 function startJapaneseCourse() {
   clearDialogue();
 
-  const course = document.createElement('div');
-  course.id = 'course-container';
-  document.body.appendChild(course);
+  const hub = document.createElement('div');
+  hub.id = 'course-hub';
 
-  // Load lesson 1
-  loadJapaneseLesson(0);
+  hub.innerHTML = `
+    <div class="hub-box">
+      <h2>Japanese Learning Hub</h2>
+      <p>What would you like to explore?</p>
+      <div class="hub-options">
+        <button onclick="loadTopic('writing')">✍️ Writing Systems</button>
+        <button onclick="loadTopic('vocab')">🧠 Vocabulary</button>
+        <button onclick="loadTopic('grammar')">📐 Grammar</button>
+        <button onclick="loadTopic('quiz')">🔁 Review & Quizzes</button>
+        <button onclick="exitCourse()">← Back to Glossarion</button>
+      </div>
+    </div>
+  `;
+
+  document.body.appendChild(hub);
+}
+
+function loadTopic(topic) {
+  alert(`Topic selected: ${topic} (content coming soon)`);
 }
 
 function clearDialogue() {

--- a/style.css
+++ b/style.css
@@ -196,3 +196,55 @@ body {
   z-index: 2000;
   border: 1px solid #27ae60;
 }
+
+#course-hub {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background: rgba(10, 10, 10, 0.95);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10000;
+  padding: 1rem;
+}
+
+.hub-box {
+  max-width: 500px;
+  width: 90vw;
+  background: #111;
+  border: 2px solid #27ae60;
+  border-radius: 10px;
+  padding: 24px;
+  text-align: center;
+  box-shadow: 0 0 20px rgba(39, 174, 96, 0.5);
+}
+
+.hub-box h2 {
+  color: #27ae60;
+  margin-bottom: 10px;
+}
+
+.hub-box p {
+  margin-bottom: 20px;
+  color: #ccc;
+}
+
+.hub-options button {
+  width: 100%;
+  margin: 8px 0;
+  padding: 12px;
+  background: #27ae60;
+  border: none;
+  color: white;
+  font-size: 1rem;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.3s ease;
+}
+
+.hub-options button:hover {
+  background: #1e8c4a;
+}


### PR DESCRIPTION
## Summary
- create a new hub UI for the Japanese course
- style hub overlay and buttons
- ensure `exitCourse` closes the hub as well

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_685af16c13948331be8a97873aa5abee