### PR TITLE
Add writing lessons and topic loader

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,8 @@
   </div>
   <div id="game-container"></div>
   <script src="script.js"></script>
+  <script src="topics.js"></script>
   <script src="lessons/japanese.js"></script>
+  <script src="lessons/writing.js"></script>
 </body>
 </html>

--- a/lessons/writing.js
+++ b/lessons/writing.js
@@ -1,0 +1,46 @@
+const writingLessons = [
+  {
+    title: "Intro to Hiragana",
+    content: `
+      <p>Hiragana (ひらがな) is the basic phonetic script of Japanese.</p>
+      <ul>
+        <li>It is used for native Japanese words and grammar markers.</li>
+        <li>Example: あ (a), い (i), う (u)</li>
+      </ul>
+    `,
+    quiz: {
+      question: "What is Hiragana used for?",
+      options: ["Foreign words", "Grammar & native words", "Scientific terms"],
+      answer: "Grammar & native words"
+    }
+  },
+  {
+    title: "Intro to Katakana",
+    content: `
+      <p>Katakana (カタカナ) is used for foreign words, loanwords, and onomatopoeia.</p>
+      <ul>
+        <li>Example: テレビ (terebi – television), パソコン (pasokon – PC)</li>
+      </ul>
+    `,
+    quiz: {
+      question: "Which script is used for loanwords?",
+      options: ["Kanji", "Hiragana", "Katakana"],
+      answer: "Katakana"
+    }
+  },
+  {
+    title: "What is Kanji?",
+    content: `
+      <p>Kanji (漢字) are Chinese-origin characters used in Japanese.</p>
+      <ul>
+        <li>Each Kanji has one or more meanings and pronunciations.</li>
+        <li>Example: 山 (mountain), 水 (water)</li>
+      </ul>
+    `,
+    quiz: {
+      question: "What does the Kanji 山 mean?",
+      options: ["Fire", "Mountain", "Tree"],
+      answer: "Mountain"
+    }
+  }
+];

--- a/script.js
+++ b/script.js
@@ -216,8 +216,47 @@ function startJapaneseCourse() {
   document.body.appendChild(hub);
 }
 
-function loadTopic(topic) {
-  alert(`Topic selected: ${topic} (content coming soon)`);
+function loadWritingLessons() {
+  if (!Array.isArray(writingLessons)) {
+    alert("Writing lessons not loaded.");
+    return;
+  }
+
+  const container = document.createElement('div');
+  container.id = 'course-container';
+  document.body.appendChild(container);
+  loadLessonFromSet(writingLessons, 0);
+}
+
+function loadLessonFromSet(lessonSet, index) {
+  const container = document.getElementById('course-container');
+  const lesson = lessonSet[index];
+
+  container.innerHTML = `
+    <div class="dialogue-box" style="max-height: 90vh; overflow-y: auto;">
+      <h2>${lesson.title}</h2>
+      ${lesson.content}
+      <p><strong>${lesson.quiz.question}</strong></p>
+      ${lesson.quiz.options.map(opt => `
+        <button onclick="checkAnswerFromSet('${opt}', '${lesson.quiz.answer}', ${index}, '${lessonSet === writingLessons ? 'writing' : 'unknown'}')">${opt}</button>
+      `).join('')}
+      <br><br>
+      <button onclick="exitCourse()">Leave Course</button>
+    </div>
+  `;
+}
+
+function checkAnswerFromSet(selected, correct, index, topicId) {
+  const box = document.querySelector('.dialogue-box');
+  const feedback = selected === correct
+    ? "<p style='color:lime'>✅ Correct!</p>"
+    : "<p style='color:orangered'>❌ Try again.</p>";
+  box.insertAdjacentHTML('beforeend', feedback);
+
+  const lessonSet = topicId === 'writing' ? writingLessons : [];
+  if (selected === correct && lessonSet[index + 1]) {
+    setTimeout(() => loadLessonFromSet(lessonSet, index + 1), 1000);
+  }
 }
 
 function clearDialogue() {

--- a/topics.js
+++ b/topics.js
@@ -1,0 +1,13 @@
+function loadTopic(topicId) {
+  // Clear the hub
+  const hub = document.getElementById('course-hub');
+  if (hub) hub.remove();
+
+  switch (topicId) {
+    case 'writing':
+      loadWritingLessons();
+      break;
+    default:
+      alert(`Unknown topic: ${topicId}`);
+  }
+}


### PR DESCRIPTION
## Summary
- implement `loadTopic` loader in new `topics.js`
- create `lessons/writing.js` with three basic lessons
- extend `script.js` to load writing lessons and provide generic lesson functions
- load new scripts in `index.html`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685afb9b14608331ab762cb5d69831a1