### PR TITLE
Fix hub viewport sizing

### DIFF
--- a/style.css
+++ b/style.css
@@ -201,14 +201,15 @@ body {
   position: fixed;
   top: 0;
   left: 0;
-  width: 100vw;
-  height: 100vh;
+  width: 100dvw; /* viewport width that ignores zoom */
+  height: 100dvh; /* viewport height that ignores zoom */
   background: rgba(10, 10, 10, 0.95);
   display: flex;
   align-items: center;
   justify-content: center;
   z-index: 10000;
   padding: 1rem;
+  overflow: hidden;
 }
 
 #course-hub::before {
@@ -222,13 +223,13 @@ body {
 
 .hub-box {
   max-width: 500px;
-  width: 90vw;
+  width: 100%;
+  padding: 20px;
   background: #111;
   border: 2px solid #27ae60;
   border-radius: 10px;
-  padding: 24px;
+  box-shadow: 0 0 20px rgba(39, 174, 96, 0.6);
   text-align: center;
-  box-shadow: 0 0 20px rgba(39, 174, 96, 0.5);
 }
 
 .hub-box h2 {


### PR DESCRIPTION
## Summary
- force `#course-hub` to use device viewport units so zoom doesn't affect size
- keep `.hub-box` bounded within the overlay

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685b13240da88331b48e8bbbd7c193f9