### PR TITLE
Add Vocabulary Topic with Lessons

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,5 +19,6 @@
   <script src="topics.js"></script>
   <script src="lessons/japanese.js"></script>
   <script src="lessons/writing.js"></script>
+  <script src="lessons/vocab.js"></script>
 </body>
 </html>

--- a/lessons/vocab.js
+++ b/lessons/vocab.js
@@ -1,0 +1,51 @@
+const vocabLessons = [
+  {
+    title: "Colors in Japanese",
+    content: `
+      <ul>
+        <li>Red – あか (aka)</li>
+        <li>Blue – あお (ao)</li>
+        <li>Green – みどり (midori)</li>
+        <li>Black – くろ (kuro)</li>
+        <li>White – しろ (shiro)</li>
+      </ul>
+    `,
+    quiz: {
+      question: "What is the Japanese word for green?",
+      options: ["みどり", "しろ", "あお"],
+      answer: "みどり"
+    }
+  },
+  {
+    title: "Animals in Japanese",
+    content: `
+      <ul>
+        <li>Dog – いぬ (inu)</li>
+        <li>Cat – ねこ (neko)</li>
+        <li>Bird – とり (tori)</li>
+        <li>Fish – さかな (sakana)</li>
+      </ul>
+    `,
+    quiz: {
+      question: "What does 'ねこ' mean?",
+      options: ["Bird", "Dog", "Cat"],
+      answer: "Cat"
+    }
+  },
+  {
+    title: "Family Terms",
+    content: `
+      <ul>
+        <li>Mother – おかあさん (okaasan)</li>
+        <li>Father – おとうさん (otousan)</li>
+        <li>Older Brother – おにいさん (oniisan)</li>
+        <li>Older Sister – おねえさん (oneesan)</li>
+      </ul>
+    `,
+    quiz: {
+      question: "What is the Japanese word for 'Father'?",
+      options: ["おかあさん", "おとうさん", "おにいさん"],
+      answer: "おとうさん"
+    }
+  }
+];

--- a/script.js
+++ b/script.js
@@ -201,6 +201,8 @@ function startJapaneseCourse() {
 
   let writingProgress = getTopicProgress('writing');
   const totalWriting = topicLessonCounts['writing'];
+  let vocabProgress = getTopicProgress('vocab');
+  const totalVocab = topicLessonCounts['vocab'];
 
   hub.innerHTML = `
     <div class="hub-box">
@@ -210,7 +212,9 @@ function startJapaneseCourse() {
         <button onclick="loadTopic('writing')">
           ✍️ Writing Systems (${writingProgress}/${totalWriting} complete)
         </button>
-        <button onclick="alert('Coming soon')">🧠 Vocabulary</button>
+        <button onclick="loadTopic('vocab')">
+          🧠 Vocabulary (${vocabProgress}/${totalVocab} complete)
+        </button>
         <button onclick="alert('Coming soon')">📐 Grammar</button>
         <button onclick="alert('Coming soon')">🔁 Quizzes</button>
         <button onclick="exitCourse()">← Back to Glossarion</button>
@@ -230,10 +234,22 @@ function loadWritingLessons() {
   const container = document.createElement('div');
   container.id = 'course-container';
   document.body.appendChild(container);
-  loadLessonFromSet(writingLessons, 0);
+  loadLessonFromSet(writingLessons, 0, 'writing');
 }
 
-function loadLessonFromSet(lessonSet, index) {
+function loadVocabLessons() {
+  if (!Array.isArray(vocabLessons)) {
+    alert("Vocabulary lessons not loaded.");
+    return;
+  }
+
+  const container = document.createElement('div');
+  container.id = 'course-container';
+  document.body.appendChild(container);
+  loadLessonFromSet(vocabLessons, 0, 'vocab');
+}
+
+function loadLessonFromSet(lessonSet, index, topicId) {
   const container = document.getElementById('course-container');
   const lesson = lessonSet[index];
 
@@ -243,7 +259,7 @@ function loadLessonFromSet(lessonSet, index) {
       ${lesson.content}
       <p><strong>${lesson.quiz.question}</strong></p>
       ${lesson.quiz.options.map(opt => `
-        <button onclick="checkAnswerFromSet('${opt}', '${lesson.quiz.answer}', ${index}, '${lessonSet === writingLessons ? 'writing' : 'unknown'}')">${opt}</button>
+        <button onclick="checkAnswerFromSet('${opt}', '${lesson.quiz.answer}', ${index}, '${topicId}')">${opt}</button>
       `).join('')}
       <br><br>
       <button onclick="exitCourse()">Leave Course</button>
@@ -265,9 +281,11 @@ function checkAnswerFromSet(selected, correct, index, topicId) {
     }
   }
 
-  const lessonSet = topicId === 'writing' ? writingLessons : [];
+  const lessonSet =
+    topicId === 'writing' ? writingLessons :
+    topicId === 'vocab' ? vocabLessons : [];
   if (selected === correct && lessonSet[index + 1]) {
-    setTimeout(() => loadLessonFromSet(lessonSet, index + 1), 1000);
+    setTimeout(() => loadLessonFromSet(lessonSet, index + 1, topicId), 1000);
   }
 }
 

--- a/topics.js
+++ b/topics.js
@@ -1,7 +1,6 @@
 const topicLessonCounts = {
   writing: 3,
-  // vocab: 5,
-  // grammar: 4,
+  vocab: 3
 };
 
 function loadTopic(topicId) {
@@ -12,6 +11,9 @@ function loadTopic(topicId) {
   switch (topicId) {
     case 'writing':
       loadWritingLessons();
+      break;
+    case 'vocab':
+      loadVocabLessons();
       break;
     default:
       alert(`Unknown topic: ${topicId}`);


### PR DESCRIPTION
## Summary
- track vocabulary lessons in topicLessonCounts
- load vocabulary lessons via hub button
- add vocab lesson data
- new loader function for vocab lessons
- show vocab progress in Japanese course hub
- include vocab lessons in HTML

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_685bcb255c008331a15d55c208383683