### PR TITLE
Add GitHub Pages home screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+# The Tabyrinth of Insight
+
+This repository includes a mobile-first home page in the `docs` directory for GitHub Pages. The landing screen provides quick links to learn Japanese and view a daily quote. The original grid game remains available via `index.html`.
+
+## Quick Start
+1. Open `docs/index.html` locally or enable GitHub Pages using the `/docs` folder.
+
 # Grid Game
 
 A simple 30×30 grid-based pathfinding game using HTML, CSS, and JavaScript. No sprites, no dependencies — pure DOM and styles. The level layout is now handcrafted rather than randomly generated.

--- a/docs/assets/css/style.css
+++ b/docs/assets/css/style.css
@@ -1,0 +1,48 @@
+body {
+  margin: 0;
+  padding: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  background: #111;
+  font-family: system-ui, sans-serif;
+  color: #fff;
+  text-align: center;
+}
+
+.logo {
+  margin-bottom: 2rem;
+}
+
+.buttons {
+  width: 90%;
+  max-width: 320px;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.btn {
+  display: block;
+  padding: 1rem;
+  font-size: 1.1rem;
+  background: linear-gradient(135deg, #27ae60, #219150);
+  color: #fff;
+  text-decoration: none;
+  border-radius: 8px;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.4);
+  transition: transform 0.1s, box-shadow 0.3s;
+}
+
+.btn:active {
+  transform: scale(0.96);
+  box-shadow: 0 2px 3px rgba(0, 0, 0, 0.4);
+}
+
+@media (min-width: 600px) {
+  body {
+    font-size: 1.1rem;
+  }
+}

--- a/docs/assets/img/labyrinth-icon.svg
+++ b/docs/assets/img/labyrinth-icon.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" fill="none">
+  <!-- Outer labyrinth/grid -->
+  <rect x="10" y="10" width="80" height="80" stroke="#ffffff" stroke-width="4" />
+  <line x1="10" y1="30" x2="90" y2="30" stroke="#ffffff" stroke-width="2" />
+  <line x1="10" y1="50" x2="90" y2="50" stroke="#ffffff" stroke-width="2" />
+  <line x1="10" y1="70" x2="90" y2="70" stroke="#ffffff" stroke-width="2" />
+  <line x1="30" y1="10" x2="30" y2="90" stroke="#ffffff" stroke-width="2" />
+  <line x1="50" y1="10" x2="50" y2="90" stroke="#ffffff" stroke-width="2" />
+  <line x1="70" y1="10" x2="70" y2="90" stroke="#ffffff" stroke-width="2" />
+
+  <!-- Central eye of insight -->
+  <circle cx="50" cy="50" r="12" fill="#ffffff" />
+  <circle cx="50" cy="50" r="4" fill="#111111" />
+</svg>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>The Tabyrinth of Insight</title>
+  <link rel="stylesheet" href="./assets/css/style.css">
+  <link rel="icon" href="./assets/img/labyrinth-icon.svg">
+</head>
+<body>
+  <img class="logo" src="./assets/img/labyrinth-icon.svg" alt="Labyrinth logo" width="80" height="80">
+  <div class="buttons">
+    <a class="btn" href="./learn.html">Learn Japanese</a>
+    <a class="btn" href="./quote.html">Daily Quote</a>
+  </div>
+</body>
+</html>

--- a/docs/learn.html
+++ b/docs/learn.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Learn Japanese</title>
+  <link rel="stylesheet" href="./assets/css/style.css">
+  <link rel="icon" href="./assets/img/labyrinth-icon.svg">
+</head>
+<body>
+  <h1>Learn Japanese</h1>
+  <p>Content coming soon.</p>
+  <p><a class="btn" href="./index.html">Back Home</a></p>
+</body>
+</html>

--- a/docs/quote.html
+++ b/docs/quote.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Daily Quote</title>
+  <link rel="stylesheet" href="./assets/css/style.css">
+  <link rel="icon" href="./assets/img/labyrinth-icon.svg">
+</head>
+<body>
+  <h1>Daily Quote</h1>
+  <p>Quote feature coming soon.</p>
+  <p><a class="btn" href="./index.html">Back Home</a></p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add mobile-first home screen in `/docs`
- add placeholder pages for Learn Japanese and Daily Quote
- include minimalist CSS for buttons
- update README with quick start info

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_686c543924b483319e2dbd19fe33fb2d