### PR TITLE
Add lessons selector view

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -42,6 +42,16 @@ body {
 .quote {
   background: linear-gradient(135deg, #2979ff, #651fff);
 }
+#lessonsView {
+  display: none;
+  flex-direction: column;
+  gap: 2vh;
+  overflow-y: auto;
+  max-height: 80vh;
+}
+.lesson {
+  background: linear-gradient(135deg, #ff8a65, #ff7043);
+}
 #quotesView {
   display: none;
   flex-direction: column;

--- a/data/lessons.json
+++ b/data/lessons.json
@@ -1,0 +1,5 @@
+[
+  {"id": 0, "title": "Alphabet", "status": "available"},
+  {"id": 1, "title": "Lesson 1", "status": "available"},
+  {"id": 2, "title": "Lesson 2", "status": "available"}
+]

--- a/index.html
+++ b/index.html
@@ -14,6 +14,9 @@
   <div id="quotesView" class="wrapper">
     <button id="backBtn" class="btn back">Back</button>
   </div>
+  <div id="lessonsView" class="wrapper">
+    <button id="lessonBackBtn" class="btn back">Back</button>
+  </div>
   <script src="js/main.js"></script>
 </body>
 </html>

--- a/js/main.js
+++ b/js/main.js
@@ -1,8 +1,11 @@
 document.addEventListener('DOMContentLoaded', () => {
   const quoteBtn = document.querySelector('.quote');
+  const learnBtn = document.querySelector('.learn');
   const wrapper = document.querySelector('.wrapper');
   const quotesView = document.getElementById('quotesView');
+  const lessonsView = document.getElementById('lessonsView');
   const backBtn = document.getElementById('backBtn');
+  const lessonBackBtn = document.getElementById('lessonBackBtn');
 
   fetch('data/quotes.json')
     .then(res => res.json())
@@ -34,6 +37,17 @@ document.addEventListener('DOMContentLoaded', () => {
       });
     });
 
+  fetch('data/lessons.json')
+    .then(res => res.json())
+    .then(data => {
+      data.forEach(lesson => {
+        const btn = document.createElement('button');
+        btn.className = 'btn lesson';
+        btn.textContent = lesson.title;
+        lessonsView.insertBefore(btn, lessonBackBtn);
+      });
+    });
+
   quoteBtn.addEventListener('click', (e) => {
     e.preventDefault();
     wrapper.style.display = 'none';
@@ -42,6 +56,17 @@ document.addEventListener('DOMContentLoaded', () => {
 
   backBtn.addEventListener('click', () => {
     quotesView.style.display = 'none';
+    wrapper.style.display = 'flex';
+  });
+
+  learnBtn.addEventListener('click', (e) => {
+    e.preventDefault();
+    wrapper.style.display = 'none';
+    lessonsView.style.display = 'flex';
+  });
+
+  lessonBackBtn.addEventListener('click', () => {
+    lessonsView.style.display = 'none';
     wrapper.style.display = 'flex';
   });
 });


### PR DESCRIPTION
## Summary
- add lessons data file
- create new lessons view container with back button
- style lesson buttons and view
- load lessons dynamically via JS
- handle navigation between landing page and lessons view

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686c77069dac8331b6ee0f73fb402919