### PR TITLE
Implement Japanese alphabet explorer

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -100,6 +100,59 @@ body {
 .back {
   background: linear-gradient(135deg, #ff1744, #d50000);
 }
+
+#alphabetView {
+  display: none;
+  flex-direction: column;
+  gap: 2vh;
+  overflow-y: auto;
+  max-height: 80vh;
+}
+
+.alphabet-nav {
+  position: sticky;
+  top: 0;
+  background: #121212;
+  display: flex;
+  gap: 1vw;
+  z-index: 5;
+}
+
+.toggle {
+  flex: 1;
+  padding: 2vh 0;
+  font-size: 1rem;
+  background: #1e1e1e;
+}
+
+.toggle.active {
+  box-shadow: 0 0 10px rgba(255,255,255,0.5);
+  filter: brightness(1.2);
+}
+
+.alphabet-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(60px, 1fr));
+  gap: 1vh;
+}
+
+.char-card {
+  background: #1e1e1e;
+  border-radius: 8px;
+  padding: 1vh;
+  text-align: center;
+}
+.char-card .kana {
+  font-size: 1.5rem;
+}
+.char-card .romaji {
+  font-size: 0.9rem;
+  margin-top: 0.5vh;
+}
+.char-card .meaning {
+  font-size: 0.8rem;
+  margin-top: 0.5vh;
+}
 @media (min-width: 481px) {
   .btn {
     font-size: 1.1rem;

--- a/data/kana.json
+++ b/data/kana.json
@@ -1,0 +1,26 @@
+{
+  "hiragana": [
+    { "kana": "あ", "romaji": "a" },
+    { "kana": "い", "romaji": "i" },
+    { "kana": "う", "romaji": "u" },
+    { "kana": "え", "romaji": "e" },
+    { "kana": "お", "romaji": "o" },
+    { "kana": "か", "romaji": "ka" },
+    { "kana": "き", "romaji": "ki" },
+    { "kana": "く", "romaji": "ku" },
+    { "kana": "け", "romaji": "ke" },
+    { "kana": "こ", "romaji": "ko" }
+  ],
+  "katakana": [
+    { "kana": "ア", "romaji": "a" },
+    { "kana": "イ", "romaji": "i" },
+    { "kana": "ウ", "romaji": "u" },
+    { "kana": "エ", "romaji": "e" },
+    { "kana": "オ", "romaji": "o" },
+    { "kana": "カ", "romaji": "ka" },
+    { "kana": "キ", "romaji": "ki" },
+    { "kana": "ク", "romaji": "ku" },
+    { "kana": "ケ", "romaji": "ke" },
+    { "kana": "コ", "romaji": "ko" }
+  ]
+}

--- a/data/kanji.json
+++ b/data/kanji.json
@@ -1,0 +1,14 @@
+{
+  "kanji": [
+    { "character": "日", "reading": "nichi / hi", "meaning": "sun, day" },
+    { "character": "月", "reading": "getsu / tsuki", "meaning": "moon, month" },
+    { "character": "火", "reading": "ka / hi", "meaning": "fire" },
+    { "character": "水", "reading": "sui / mizu", "meaning": "water" },
+    { "character": "木", "reading": "moku / ki", "meaning": "tree" },
+    { "character": "金", "reading": "kin / kane", "meaning": "gold, money" },
+    { "character": "土", "reading": "do / tsuchi", "meaning": "earth" },
+    { "character": "山", "reading": "san / yama", "meaning": "mountain" },
+    { "character": "川", "reading": "sen / kawa", "meaning": "river" },
+    { "character": "人", "reading": "jin / hito", "meaning": "person" }
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -17,6 +17,15 @@
   <div id="lessonsView" class="wrapper">
     <button id="lessonBackBtn" class="btn back">Back</button>
   </div>
+  <div id="alphabetView" class="wrapper">
+    <div class="alphabet-nav">
+      <button id="hiraganaBtn" class="btn toggle active">Hiragana</button>
+      <button id="katakanaBtn" class="btn toggle">Katakana</button>
+      <button id="kanjiBtn" class="btn toggle">Kanji</button>
+    </div>
+    <div id="alphabetGrid" class="alphabet-grid"></div>
+    <button id="alphabetBackBtn" class="btn back">Back</button>
+  </div>
   <script src="js/main.js"></script>
 </body>
 </html>

--- a/js/main.js
+++ b/js/main.js
@@ -6,6 +6,15 @@ document.addEventListener('DOMContentLoaded', () => {
   const lessonsView = document.getElementById('lessonsView');
   const backBtn = document.getElementById('backBtn');
   const lessonBackBtn = document.getElementById('lessonBackBtn');
+  const alphabetView = document.getElementById('alphabetView');
+  const alphabetGrid = document.getElementById('alphabetGrid');
+  const alphabetBackBtn = document.getElementById('alphabetBackBtn');
+  const hBtn = document.getElementById('hiraganaBtn');
+  const kBtn = document.getElementById('katakanaBtn');
+  const kanjiBtn = document.getElementById('kanjiBtn');
+
+  let kanaData = { hiragana: [], katakana: [] };
+  let kanjiData = [];
 
   fetch('data/quotes.json')
     .then(res => res.json())
@@ -45,7 +54,26 @@ document.addEventListener('DOMContentLoaded', () => {
         btn.className = 'btn lesson';
         btn.textContent = lesson.title;
         lessonsView.insertBefore(btn, lessonBackBtn);
+        if (lesson.title === 'Alphabet') {
+          btn.addEventListener('click', () => {
+            lessonsView.style.display = 'none';
+            alphabetView.style.display = 'flex';
+            showSet('hiragana');
+          });
+        }
       });
+    });
+
+  fetch('data/kana.json')
+    .then(res => res.json())
+    .then(data => {
+      kanaData = data;
+    });
+
+  fetch('data/kanji.json')
+    .then(res => res.json())
+    .then(data => {
+      kanjiData = data.kanji;
     });
 
   quoteBtn.addEventListener('click', (e) => {
@@ -69,4 +97,44 @@ document.addEventListener('DOMContentLoaded', () => {
     lessonsView.style.display = 'none';
     wrapper.style.display = 'flex';
   });
+
+  alphabetBackBtn.addEventListener('click', () => {
+    alphabetView.style.display = 'none';
+    lessonsView.style.display = 'flex';
+  });
+
+  hBtn.addEventListener('click', () => showSet('hiragana'));
+  kBtn.addEventListener('click', () => showSet('katakana'));
+  kanjiBtn.addEventListener('click', () => showSet('kanji'));
+
+  function clearActive() {
+    [hBtn, kBtn, kanjiBtn].forEach(b => b.classList.remove('active'));
+  }
+
+  function showSet(type) {
+    clearActive();
+    if (type === 'hiragana') hBtn.classList.add('active');
+    if (type === 'katakana') kBtn.classList.add('active');
+    if (type === 'kanji') kanjiBtn.classList.add('active');
+
+    alphabetGrid.innerHTML = '';
+    if (type === 'kanji') {
+      kanjiData.forEach(k => {
+        const card = document.createElement('div');
+        card.className = 'char-card';
+        card.innerHTML = `<div class="kana">${k.character}</div>` +
+                         `<div class="romaji">${k.reading}</div>` +
+                         `<div class="meaning">${k.meaning}</div>`;
+        alphabetGrid.appendChild(card);
+      });
+    } else {
+      kanaData[type].forEach(k => {
+        const card = document.createElement('div');
+        card.className = 'char-card';
+        card.innerHTML = `<div class="kana">${k.kana}</div>` +
+                         `<div class="romaji">${k.romaji}</div>`;
+        alphabetGrid.appendChild(card);
+      });
+    }
+  }
 });


### PR DESCRIPTION
## Summary
- add kana and kanji data sets
- create Alphabet view with category toggles
- style alphabet UI and character grid
- load and display Hiragana, Katakana and Kanji from JSON

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686c78703cac833189e7814732c27706