### PR TITLE
Reset alphabet view on back navigation

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -162,3 +162,15 @@ body {
     font-size: 1.1rem;
   }
 }
+
+.hidden {
+  display: none !important;
+}
+
+.fade-out {
+  animation: fadeOut 0.3s forwards;
+}
+
+@keyframes fadeOut {
+  to { opacity: 0; }
+}

--- a/js/main.js
+++ b/js/main.js
@@ -56,7 +56,8 @@ document.addEventListener('DOMContentLoaded', () => {
         lessonsView.insertBefore(btn, lessonBackBtn);
         if (lesson.title === 'Alphabet') {
           btn.addEventListener('click', () => {
-            lessonsView.style.display = 'none';
+            hideAllViews();
+            resetAlphabet();
             alphabetView.style.display = 'flex';
             showSet('hiragana');
           });
@@ -76,31 +77,49 @@ document.addEventListener('DOMContentLoaded', () => {
       kanjiData = data.kanji;
     });
 
+  function hideAllViews() {
+    wrapper.style.display = 'none';
+    quotesView.style.display = 'none';
+    lessonsView.style.display = 'none';
+    alphabetView.style.display = 'none';
+  }
+
+  function resetAlphabet() {
+    alphabetGrid.innerHTML = '';
+    clearActive();
+    alphabetView.scrollTop = 0;
+  }
+
   quoteBtn.addEventListener('click', (e) => {
     e.preventDefault();
-    wrapper.style.display = 'none';
+    hideAllViews();
     quotesView.style.display = 'flex';
   });
 
   backBtn.addEventListener('click', () => {
-    quotesView.style.display = 'none';
+    hideAllViews();
     wrapper.style.display = 'flex';
   });
 
   learnBtn.addEventListener('click', (e) => {
     e.preventDefault();
-    wrapper.style.display = 'none';
+    hideAllViews();
     lessonsView.style.display = 'flex';
   });
 
   lessonBackBtn.addEventListener('click', () => {
-    lessonsView.style.display = 'none';
+    hideAllViews();
     wrapper.style.display = 'flex';
   });
 
   alphabetBackBtn.addEventListener('click', () => {
-    alphabetView.style.display = 'none';
-    lessonsView.style.display = 'flex';
+    alphabetView.classList.add('fade-out');
+    setTimeout(() => {
+      resetAlphabet();
+      hideAllViews();
+      lessonsView.style.display = 'flex';
+      alphabetView.classList.remove('fade-out');
+    }, 300);
   });
 
   hBtn.addEventListener('click', () => showSet('hiragana'));


### PR DESCRIPTION
## Summary
- add helper classes for hiding and fade-out animation
- manage view transitions with `hideAllViews`
- clear and reset alphabet grid on exit
- fade alphabet view when leaving

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686c7fac792c8331950fab3d6c680d15