### PR TITLE
Add grade 1 kanji data and grid

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -172,6 +172,10 @@ body {
   font-size: 0.8rem;
   margin-top: 0.5vh;
 }
+
+.char-card:active {
+  box-shadow: 0 0 10px rgba(255,255,255,0.5);
+}
 @media (min-width: 481px) {
   .btn {
     font-size: 1.1rem;

--- a/data/kanji.json
+++ b/data/kanji.json
@@ -1,16 +1,136 @@
 {
   "kanji": [
-    { "character": "日", "reading": "nichi / hi", "meaning": "sun, day" },
-    { "character": "月", "reading": "getsu / tsuki", "meaning": "moon, month" },
-    { "character": "山", "reading": "san / yama", "meaning": "mountain" },
-    { "character": "水", "reading": "sui / mizu", "meaning": "water" },
-    { "character": "火", "reading": "ka / hi", "meaning": "fire" },
-    { "character": "木", "reading": "moku / ki", "meaning": "tree" },
-    { "character": "金", "reading": "kin / kane", "meaning": "gold, money" },
-    { "character": "人", "reading": "jin / hito", "meaning": "person" },
-    { "character": "大", "reading": "dai / oo", "meaning": "big" },
-    { "character": "小", "reading": "shou / chii", "meaning": "small" },
-    { "character": "土", "reading": "do / tsuchi", "meaning": "earth" },
-    { "character": "川", "reading": "sen / kawa", "meaning": "river" }
+    {
+      "character": "日",
+      "readings": ["nichi", "hi"],
+      "meaning": "sun, day",
+      "grade": 1
+    },
+    {
+      "character": "月",
+      "readings": ["getsu", "tsuki"],
+      "meaning": "moon, month",
+      "grade": 1
+    },
+    {
+      "character": "山",
+      "readings": ["san", "yama"],
+      "meaning": "mountain",
+      "grade": 1
+    },
+    {
+      "character": "水",
+      "readings": ["mizu"],
+      "meaning": "water",
+      "grade": 1
+    },
+    {
+      "character": "火",
+      "readings": ["hi"],
+      "meaning": "fire",
+      "grade": 1
+    },
+    {
+      "character": "木",
+      "readings": ["ki"],
+      "meaning": "tree, wood",
+      "grade": 1
+    },
+    {
+      "character": "金",
+      "readings": ["kin", "kane"],
+      "meaning": "gold, money",
+      "grade": 1
+    },
+    {
+      "character": "人",
+      "readings": ["hito"],
+      "meaning": "person",
+      "grade": 1
+    },
+    {
+      "character": "大",
+      "readings": ["dai", "ookii"],
+      "meaning": "big",
+      "grade": 1
+    },
+    {
+      "character": "小",
+      "readings": ["shou", "chiisai"],
+      "meaning": "small",
+      "grade": 1
+    },
+    {
+      "character": "上",
+      "readings": ["ue"],
+      "meaning": "up",
+      "grade": 1
+    },
+    {
+      "character": "下",
+      "readings": ["shita"],
+      "meaning": "down",
+      "grade": 1
+    },
+    {
+      "character": "中",
+      "readings": ["naka"],
+      "meaning": "inside, middle",
+      "grade": 1
+    },
+    {
+      "character": "右",
+      "readings": ["migi"],
+      "meaning": "right",
+      "grade": 1
+    },
+    {
+      "character": "左",
+      "readings": ["hidari"],
+      "meaning": "left",
+      "grade": 1
+    },
+    {
+      "character": "生",
+      "readings": ["sei", "ikiru"],
+      "meaning": "life, to live",
+      "grade": 1
+    },
+    {
+      "character": "学",
+      "readings": ["gaku", "manabu"],
+      "meaning": "study, learning",
+      "grade": 1
+    },
+    {
+      "character": "校",
+      "readings": ["kou"],
+      "meaning": "school",
+      "grade": 1
+    },
+    {
+      "character": "先",
+      "readings": ["sen"],
+      "meaning": "ahead, previous",
+      "grade": 1
+    },
+    {
+      "character": "年",
+      "readings": ["nen", "toshi"],
+      "meaning": "year",
+      "grade": 1
+    },
+    {
+      "character": "土",
+      "readings": ["do", "tsuchi"],
+      "meaning": "earth",
+      "grade": 1
+    },
+    {
+      "character": "川",
+      "readings": ["kawa"],
+      "meaning": "river",
+      "grade": 1
+    }
   ]
 }

--- a/js/main.js
+++ b/js/main.js
@@ -138,14 +138,23 @@ document.addEventListener('DOMContentLoaded', () => {
 
     alphabetGrid.innerHTML = '';
     if (type === 'kanji') {
+      const title = document.createElement('h3');
+      title.className = 'kana-section-title';
+      title.textContent = 'Grade 1 Kanji';
+      alphabetGrid.appendChild(title);
+
+      const grid = document.createElement('div');
+      grid.className = 'alphabet-grid';
       kanjiData.forEach(k => {
         const card = document.createElement('div');
         card.className = 'char-card';
+        const readings = Array.isArray(k.readings) ? k.readings.join(' / ') : k.readings;
         card.innerHTML = `<div class="kana">${k.character}</div>` +
-                         `<div class="romaji">${k.reading}</div>` +
+                         `<div class="romaji">${readings}</div>` +
                          `<div class="meaning">${k.meaning}</div>`;
-        alphabetGrid.appendChild(card);
+        grid.appendChild(card);
       });
+      alphabetGrid.appendChild(grid);
     } else if (type === 'hiragana' || type === 'katakana') {
       const groups = kanaData[type].reduce((acc, k) => {
         (acc[k.type] = acc[k.type] || []).push(k);


### PR DESCRIPTION
## Summary
- restructure `kanji.json` and add 22 grade‑1 kanji entries
- update `showSet` in `main.js` to render a headed kanji grid
- add active style for character cards

## Testing
- `python3 -m json.tool data/kanji.json`

------
https://chatgpt.com/codex/tasks/task_e_686d855381cc833190fbd01b0200d1b6