### PR TITLE
Implement deferred retry logic for lesson quiz

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -233,6 +233,7 @@ body {
   border-radius: 6px;
   color: #fff;
   margin-bottom: 1vh;
+  text-align: center;
 }
 
 .quiz-feedback {
@@ -247,4 +248,11 @@ body {
 
 .quiz-feedback.wrong {
   color: #ff5252;
+}
+
+/* Highlight style for retry questions */
+.retry .quiz-prompt {
+  background: rgba(255, 255, 255, 0.1);
+  padding: 1vh;
+  border-radius: 6px;
 }

--- a/js/lesson1.js
+++ b/js/lesson1.js
@@ -4,17 +4,29 @@ document.addEventListener('DOMContentLoaded', () => {
   const lesson1BackBtn = document.getElementById('lesson1BackBtn');
   const lessonsView = document.getElementById('lessonsView');
 
-  let questions = [];
+  let firstPass = [];
+  let retryQueue = [];
   let current = 0;
-  let score = 0;
+  let retryIndex = 0;
+  let inRetry = false;
+
+  let correctFirst = 0;
+  let correctSecond = 0;
 
   function loadQuestions() {
-    return fetch('lessons/lesson1.json')
-      .then(res => res.json());
+    return fetch('lessons/lesson1.json').then(res => res.json());
   }
 
   function showScore() {
-    lesson1Content.innerHTML = `\n      <h3 class="final-score">You got ${score}/${questions.length} correct!</h3>\n    `;
+    const totalCorrect = correctFirst + correctSecond;
+    const incorrect = firstPass.length - totalCorrect;
+    lesson1Content.classList.remove('retry');
+    lesson1Content.innerHTML = `
+      <h3 class="final-score">📝 Score: ${totalCorrect}/${firstPass.length}</h3>
+      <p>${correctFirst} correct on first try</p>
+      <p>${correctSecond} correct on second try</p>
+      <p>${incorrect} incorrect</p>
+    `;
     const retry = document.createElement('button');
     retry.className = 'btn retry-btn';
     retry.textContent = 'Retry';
@@ -22,55 +34,91 @@ document.addEventListener('DOMContentLoaded', () => {
     lesson1Content.appendChild(retry);
   }
 
-  function handleSubmit(input, q, submitBtn) {
+  function handleSubmit(input, q, submitBtn, isRetry) {
     if (input.disabled) return;
     const user = input.value.trim();
     if (!user) return;
-    const feedback = document.createElement('div');
-    feedback.className = 'quiz-feedback';
-    if (user.toLowerCase() === q.answer.toLowerCase()) {
-      feedback.textContent = '✅ Correct';
-      feedback.classList.add('correct');
-      score++;
-    } else {
-      feedback.textContent = `❌ Incorrect. ${q.answer}`;
-      feedback.classList.add('wrong');
-    }
+
+    const correct = user.toLowerCase() === q.answer.toLowerCase();
     input.disabled = true;
     submitBtn.disabled = true;
-    lesson1Content.appendChild(feedback);
+
+    if (correct) {
+      const msg = document.createElement('div');
+      msg.className = 'quiz-feedback correct';
+      msg.textContent = isRetry ? '✅ Correct on second attempt!' : '✅ Correct!';
+      lesson1Content.appendChild(msg);
+      if (isRetry) correctSecond++; else correctFirst++;
+    } else {
+      const wrong = document.createElement('div');
+      wrong.className = 'quiz-feedback wrong';
+      wrong.textContent = `❌ Incorrect. Correct answer: ${q.answer}`;
+      lesson1Content.appendChild(wrong);
+      if (!isRetry) {
+        const retryNote = document.createElement('div');
+        retryNote.className = 'quiz-feedback';
+        retryNote.textContent = '🔁 You\u2019ll retry this question later.';
+        lesson1Content.appendChild(retryNote);
+        retryQueue.push(q);
+      } else {
+        const finalNote = document.createElement('div');
+        finalNote.className = 'quiz-feedback wrong';
+        finalNote.textContent = `Still incorrect. Final answer: ${q.answer}`;
+        lesson1Content.appendChild(finalNote);
+      }
+    }
 
     const next = document.createElement('button');
     next.className = 'btn next-btn';
-    next.textContent = current === questions.length - 1 ? 'Finish' : 'Next';
+    const lastFirst = !inRetry && current === firstPass.length - 1;
+    const lastRetry = inRetry && retryIndex === retryQueue.length - 1;
+    next.textContent = (lastFirst && retryQueue.length === 0) || lastRetry ? 'Finish' : 'Next';
     next.addEventListener('click', () => {
-      current++;
-      if (current < questions.length) {
-        showQuestion();
+      if (!inRetry) {
+        current++;
+        if (current < firstPass.length) {
+          showQuestion();
+        } else if (retryQueue.length > 0) {
+          inRetry = true;
+          retryIndex = 0;
+          showQuestion();
+        } else {
+          showScore();
+        }
       } else {
-        showScore();
+        retryIndex++;
+        if (retryIndex < retryQueue.length) {
+          showQuestion();
+        } else {
+          showScore();
+        }
       }
     });
     lesson1Content.appendChild(next);
   }
 
   function showQuestion() {
-    const q = questions[current];
     lesson1Content.innerHTML = '';
+    const q = inRetry ? retryQueue[retryIndex] : firstPass[current];
+    lesson1Content.classList.toggle('retry', inRetry);
+
     const promptEl = document.createElement('div');
     promptEl.className = 'quiz-prompt';
     promptEl.textContent = `What is ${q.prompt}?`;
+
     const input = document.createElement('input');
     input.type = 'text';
     input.className = 'quiz-input';
     input.autofocus = true;
+
     const submitBtn = document.createElement('button');
     submitBtn.className = 'btn quiz-submit';
     submitBtn.textContent = 'Submit';
-    submitBtn.addEventListener('click', () => handleSubmit(input, q, submitBtn));
+    submitBtn.addEventListener('click', () => handleSubmit(input, q, submitBtn, inRetry));
     input.addEventListener('keypress', (e) => {
-      if (e.key === 'Enter') handleSubmit(input, q, submitBtn);
+      if (e.key === 'Enter') handleSubmit(input, q, submitBtn, inRetry);
     });
+
     lesson1Content.appendChild(promptEl);
     lesson1Content.appendChild(input);
     lesson1Content.appendChild(submitBtn);
@@ -78,10 +126,15 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function startQuiz() {
     current = 0;
-    score = 0;
+    retryIndex = 0;
+    inRetry = false;
+    correctFirst = 0;
+    correctSecond = 0;
+    retryQueue = [];
+    lesson1Content.classList.remove('retry');
     loadQuestions()
       .then(qs => {
-        questions = qs.sort(() => Math.random() - 0.5);
+        firstPass = qs.sort(() => Math.random() - 0.5);
         showQuestion();
       })
       .catch(err => {


### PR DESCRIPTION
## Summary
- center text in the lesson input field
- highlight retry questions
- overhaul Lesson 1 quiz to show missed questions again after first pass

## Testing
- `node -c js/lesson1.js`

------
https://chatgpt.com/codex/tasks/task_e_686d9bbcacf4833194a7a553e1340238