### PR TITLE
Add multiple choice lesson and revert lesson1

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,6 +21,10 @@
     <div id="lesson1Content"></div>
     <button id="lesson1BackBtn" class="btn back">Back</button>
   </div>
+  <div id="lesson2View" class="wrapper" style="display:none;">
+    <div id="lesson2Content"></div>
+    <button id="lesson2BackBtn" class="btn back">Back</button>
+  </div>
   <div id="alphabetView" class="wrapper">
     <div class="alphabet-nav">
       <button id="hiraganaBtn" class="btn toggle active">Hiragana</button>
@@ -32,5 +36,6 @@
   </div>
   <script src="js/main.js"></script>
   <script src="js/lesson1.js"></script>
+  <script src="js/lesson2.js"></script>
 </body>
 </html>

--- a/js/lesson2.js
+++ b/js/lesson2.js
@@ -1,7 +1,7 @@
 document.addEventListener('DOMContentLoaded', () => {
-  const lesson1View = document.getElementById('lesson1View');
-  const lesson1Content = document.getElementById('lesson1Content');
-  const lesson1BackBtn = document.getElementById('lesson1BackBtn');
+  const lesson2View = document.getElementById('lesson2View');
+  const lesson2Content = document.getElementById('lesson2Content');
+  const lesson2BackBtn = document.getElementById('lesson2BackBtn');
   const lessonsView = document.getElementById('lessonsView');
 
   let firstPass = [];
@@ -14,14 +14,14 @@ document.addEventListener('DOMContentLoaded', () => {
   let correctSecond = 0;
 
   function loadQuestions() {
-    return fetch('lessons/lesson1.json').then(res => res.json());
+    return fetch('lessons/lesson2.json').then(res => res.json());
   }
 
   function showScore() {
     const totalCorrect = correctFirst + correctSecond;
     const incorrect = firstPass.length - totalCorrect;
-    lesson1Content.classList.remove('retry');
-    lesson1Content.innerHTML = `
+    lesson2Content.classList.remove('retry');
+    lesson2Content.innerHTML = `
       <h3 class="final-score">📝 Score: ${totalCorrect}/${firstPass.length}</h3>
       <p>${correctFirst} correct on first try</p>
       <p>${correctSecond} correct on second try</p>
@@ -31,7 +31,7 @@ document.addEventListener('DOMContentLoaded', () => {
     retry.className = 'btn retry-btn';
     retry.textContent = 'Retry';
     retry.addEventListener('click', startQuiz);
-    lesson1Content.appendChild(retry);
+    lesson2Content.appendChild(retry);
   }
 
   function handleSubmit(input, q, submitBtn, isRetry) {
@@ -47,24 +47,24 @@ document.addEventListener('DOMContentLoaded', () => {
       const msg = document.createElement('div');
       msg.className = 'quiz-feedback correct';
       msg.textContent = isRetry ? '✅ Correct on second attempt!' : '✅ Correct!';
-      lesson1Content.appendChild(msg);
+      lesson2Content.appendChild(msg);
       if (isRetry) correctSecond++; else correctFirst++;
     } else {
       const wrong = document.createElement('div');
       wrong.className = 'quiz-feedback wrong';
       wrong.textContent = `❌ Incorrect. Correct answer: ${q.answer}`;
-      lesson1Content.appendChild(wrong);
+      lesson2Content.appendChild(wrong);
       if (!isRetry) {
         const retryNote = document.createElement('div');
         retryNote.className = 'quiz-feedback';
         retryNote.textContent = '🔁 You\u2019ll retry this question later.';
-        lesson1Content.appendChild(retryNote);
+        lesson2Content.appendChild(retryNote);
         retryQueue.push(q);
       } else {
         const finalNote = document.createElement('div');
         finalNote.className = 'quiz-feedback wrong';
         finalNote.textContent = `Still incorrect. Final answer: ${q.answer}`;
-        lesson1Content.appendChild(finalNote);
+        lesson2Content.appendChild(finalNote);
       }
     }
 
@@ -94,19 +94,82 @@ document.addEventListener('DOMContentLoaded', () => {
         }
       }
     });
-    lesson1Content.appendChild(next);
+    lesson2Content.appendChild(next);
   }
 
+  function handleChoice(btn, buttons, q, isRetry) {
+    if (btn.disabled) return;
+    buttons.forEach(b => b.disabled = true);
+    const user = btn.textContent.trim();
+    const correct = user.toLowerCase() === q.answer.toLowerCase();
+
+    if (correct) {
+      btn.classList.add('correct');
+      const msg = document.createElement('div');
+      msg.className = 'quiz-feedback correct';
+      msg.textContent = isRetry ? '✅ Correct on second attempt!' : '✅ Correct!';
+      lesson2Content.appendChild(msg);
+      if (isRetry) correctSecond++; else correctFirst++;
+    } else {
+      btn.classList.add('wrong');
+      const right = buttons.find(b => b.textContent.trim() === q.answer);
+      if (right) right.classList.add('correct');
+      const wrong = document.createElement('div');
+      wrong.className = 'quiz-feedback wrong';
+      wrong.textContent = `❌ Incorrect. Correct answer: ${q.answer}`;
+      lesson2Content.appendChild(wrong);
+      if (!isRetry) {
+        const retryNote = document.createElement('div');
+        retryNote.className = 'quiz-feedback';
+        retryNote.textContent = '🔁 You\u2019ll retry this question later.';
+        lesson2Content.appendChild(retryNote);
+        retryQueue.push(q);
+      } else {
+        const finalNote = document.createElement('div');
+        finalNote.className = 'quiz-feedback wrong';
+        finalNote.textContent = `Still incorrect. Final answer: ${q.answer}`;
+        lesson2Content.appendChild(finalNote);
+      }
+    }
+
+    const next = document.createElement('button');
+    next.className = 'btn next-btn';
+    const lastFirst = !inRetry && current === firstPass.length - 1;
+    const lastRetry = inRetry && retryIndex === retryQueue.length - 1;
+    next.textContent = (lastFirst && retryQueue.length === 0) || lastRetry ? 'Finish' : 'Next';
+    next.addEventListener('click', () => {
+      if (!inRetry) {
+        current++;
+        if (current < firstPass.length) {
+          showQuestion();
+        } else if (retryQueue.length > 0) {
+          inRetry = true;
+          retryIndex = 0;
+          showQuestion();
+        } else {
+          showScore();
+        }
+      } else {
+        retryIndex++;
+        if (retryIndex < retryQueue.length) {
+          showQuestion();
+        } else {
+          showScore();
+        }
+      }
+    });
+    lesson2Content.appendChild(next);
+  }
 
   function showQuestion() {
-    lesson1Content.innerHTML = '';
+    lesson2Content.innerHTML = '';
     const q = inRetry ? retryQueue[retryIndex] : firstPass[current];
-    lesson1Content.classList.toggle('retry', inRetry);
+    lesson2Content.classList.toggle('retry', inRetry);
 
     const promptEl = document.createElement('div');
     promptEl.className = 'quiz-prompt';
     promptEl.textContent = `What is ${q.prompt}?`;
-    lesson1Content.appendChild(promptEl);
+    lesson2Content.appendChild(promptEl);
 
     if (q.type === 'input') {
       const input = document.createElement('input');
@@ -122,8 +185,18 @@ document.addEventListener('DOMContentLoaded', () => {
         if (e.key === 'Enter') handleSubmit(input, q, submitBtn, inRetry);
       });
 
-      lesson1Content.appendChild(input);
-      lesson1Content.appendChild(submitBtn);
+      lesson2Content.appendChild(input);
+      lesson2Content.appendChild(submitBtn);
+    } else if (q.type === 'multiple-choice') {
+      const buttons = [];
+      q.choices.forEach(choice => {
+        const b = document.createElement('button');
+        b.className = 'btn quiz-option';
+        b.textContent = choice;
+        b.addEventListener('click', () => handleChoice(b, buttons, q, inRetry));
+        buttons.push(b);
+        lesson2Content.appendChild(b);
+      });
     }
   }
 
@@ -134,26 +207,26 @@ document.addEventListener('DOMContentLoaded', () => {
     correctFirst = 0;
     correctSecond = 0;
     retryQueue = [];
-    lesson1Content.classList.remove('retry');
+    lesson2Content.classList.remove('retry');
     loadQuestions()
       .then(qs => {
         firstPass = qs.sort(() => Math.random() - 0.5);
         showQuestion();
       })
       .catch(err => {
-        lesson1Content.textContent = 'Failed to load lesson.';
+        lesson2Content.textContent = 'Failed to load lesson.';
         console.error(err);
       });
   }
 
-  window.startLesson1 = startQuiz;
+  window.startLesson2 = startQuiz;
 
-  lesson1BackBtn.addEventListener('click', () => {
-    lesson1View.classList.add('fade-out');
+  lesson2BackBtn.addEventListener('click', () => {
+    lesson2View.classList.add('fade-out');
     setTimeout(() => {
-      lesson1Content.innerHTML = '';
-      lesson1View.style.display = 'none';
-      lesson1View.classList.remove('fade-out');
+      lesson2Content.innerHTML = '';
+      lesson2View.style.display = 'none';
+      lesson2View.classList.remove('fade-out');
       lessonsView.style.display = 'flex';
     }, 300);
   });

--- a/js/main.js
+++ b/js/main.js
@@ -7,6 +7,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const backBtn = document.getElementById('backBtn');
   const lessonBackBtn = document.getElementById('lessonBackBtn');
   const lesson1View = document.getElementById('lesson1View');
+  const lesson2View = document.getElementById('lesson2View');
   const alphabetView = document.getElementById('alphabetView');
   const alphabetGrid = document.getElementById('alphabetGrid');
   const alphabetBackBtn = document.getElementById('alphabetBackBtn');
@@ -70,6 +71,12 @@ document.addEventListener('DOMContentLoaded', () => {
             lesson1View.style.display = 'flex';
             if (typeof startLesson1 === 'function') startLesson1();
           });
+        } else if (lesson.title === 'Lesson 2') {
+          btn.addEventListener('click', () => {
+            hideAllViews();
+            lesson2View.style.display = 'flex';
+            if (typeof startLesson2 === 'function') startLesson2();
+          });
         }
       });
     })
@@ -100,6 +107,7 @@ document.addEventListener('DOMContentLoaded', () => {
     quotesView.style.display = 'none';
     lessonsView.style.display = 'none';
     lesson1View.style.display = 'none';
+    lesson2View.style.display = 'none';
     alphabetView.style.display = 'none';
   }
 

--- a/lessons/lesson1.json
+++ b/lessons/lesson1.json
@@ -9,9 +9,4 @@
   {"type": "input", "direction": "romaji-to-kana", "prompt": "ri", "answer": "り"},
   {"type": "input", "direction": "romaji-to-kana", "prompt": "se", "answer": "せ"},
   {"type": "input", "direction": "romaji-to-kana", "prompt": "nu", "answer": "ぬ"},
-  {"type": "multiple-choice", "direction": "kana-to-romaji", "prompt": "く", "answer": "ku", "choices": ["ki", "ku", "ko", "ka"]},
-  {"type": "multiple-choice", "direction": "kana-to-romaji", "prompt": "あ", "answer": "a", "choices": ["e", "o", "a", "i"]},
-  {"type": "multiple-choice", "direction": "kana-to-romaji", "prompt": "も", "answer": "mo", "choices": ["mu", "ma", "mi", "mo"]},
-  {"type": "multiple-choice", "direction": "romaji-to-kana", "prompt": "so", "answer": "そ", "choices": ["さ", "そ", "す", "せ"]},
-  {"type": "multiple-choice", "direction": "romaji-to-kana", "prompt": "ri", "answer": "り", "choices": ["れ", "ら", "り", "る"]}
 ]

--- a/lessons/lesson2.json
+++ b/lessons/lesson2.json
@@ -1,0 +1,12 @@
+[
+  {"type": "multiple-choice", "direction": "kana-to-romaji", "prompt": "あ", "answer": "a", "choices": ["e", "o", "a", "i"]},
+  {"type": "multiple-choice", "direction": "kana-to-romaji", "prompt": "く", "answer": "ku", "choices": ["ki", "ku", "ko", "ka"]},
+  {"type": "multiple-choice", "direction": "kana-to-romaji", "prompt": "て", "answer": "te", "choices": ["ta", "te", "to", "ti"]},
+  {"type": "multiple-choice", "direction": "kana-to-romaji", "prompt": "ね", "answer": "ne", "choices": ["ni", "no", "na", "ne"]},
+  {"type": "multiple-choice", "direction": "kana-to-romaji", "prompt": "も", "answer": "mo", "choices": ["mu", "ma", "mi", "mo"]},
+  {"type": "multiple-choice", "direction": "romaji-to-kana", "prompt": "ka", "answer": "か", "choices": ["か", "き", "く", "け"]},
+  {"type": "multiple-choice", "direction": "romaji-to-kana", "prompt": "su", "answer": "す", "choices": ["せ", "す", "さ", "そ"]},
+  {"type": "multiple-choice", "direction": "romaji-to-kana", "prompt": "ri", "answer": "り", "choices": ["ら", "り", "れ", "る"]},
+  {"type": "multiple-choice", "direction": "romaji-to-kana", "prompt": "se", "answer": "せ", "choices": ["そ", "せ", "さ", "し"]},
+  {"type": "multiple-choice", "direction": "romaji-to-kana", "prompt": "nu", "answer": "ぬ", "choices": ["ね", "ぬ", "の", "に"]}
+]


### PR DESCRIPTION
## Summary
- revert Lesson 1 to input-only quiz
- create Lesson 2 as a multiple-choice variant
- wire up Lesson 2 in the main menu
- include new view and script in HTML

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686daba219008331a9a9080f2cc14655