### PR TITLE
Add Katakana quiz lesson

### DIFF
--- a/lessons/lesson2.json
+++ b/lessons/lesson2.json
@@ -1,12 +1,12 @@
 [
-  {"type": "multiple-choice", "direction": "kana-to-romaji", "prompt": "あ", "answer": "a", "choices": ["e", "o", "a", "i"]},
-  {"type": "multiple-choice", "direction": "kana-to-romaji", "prompt": "く", "answer": "ku", "choices": ["ki", "ku", "ko", "ka"]},
-  {"type": "multiple-choice", "direction": "kana-to-romaji", "prompt": "て", "answer": "te", "choices": ["ta", "te", "to", "ti"]},
-  {"type": "multiple-choice", "direction": "kana-to-romaji", "prompt": "ね", "answer": "ne", "choices": ["ni", "no", "na", "ne"]},
-  {"type": "multiple-choice", "direction": "kana-to-romaji", "prompt": "も", "answer": "mo", "choices": ["mu", "ma", "mi", "mo"]},
-  {"type": "multiple-choice", "direction": "romaji-to-kana", "prompt": "ka", "answer": "か", "choices": ["か", "き", "く", "け"]},
-  {"type": "multiple-choice", "direction": "romaji-to-kana", "prompt": "su", "answer": "す", "choices": ["せ", "す", "さ", "そ"]},
-  {"type": "multiple-choice", "direction": "romaji-to-kana", "prompt": "ri", "answer": "り", "choices": ["ら", "り", "れ", "る"]},
-  {"type": "multiple-choice", "direction": "romaji-to-kana", "prompt": "se", "answer": "せ", "choices": ["そ", "せ", "さ", "し"]},
-  {"type": "multiple-choice", "direction": "romaji-to-kana", "prompt": "nu", "answer": "ぬ", "choices": ["ね", "ぬ", "の", "に"]}
+  {"type": "input", "direction": "kana-to-romaji", "prompt": "カ", "answer": "ka"},
+  {"type": "input", "direction": "kana-to-romaji", "prompt": "ツ", "answer": "tsu"},
+  {"type": "input", "direction": "kana-to-romaji", "prompt": "ノ", "answer": "no"},
+  {"type": "input", "direction": "romaji-to-kana", "prompt": "me", "answer": "メ"},
+  {"type": "input", "direction": "romaji-to-kana", "prompt": "ro", "answer": "ロ"},
+  {"type": "multiple-choice", "direction": "kana-to-romaji", "prompt": "セ", "answer": "se", "choices": ["se", "so", "sa", "ne"]},
+  {"type": "multiple-choice", "direction": "kana-to-romaji", "prompt": "ヨ", "answer": "yo", "choices": ["ya", "yu", "yo", "wa"]},
+  {"type": "multiple-choice", "direction": "romaji-to-kana", "prompt": "ta", "answer": "タ", "choices": ["チ", "タ", "テ", "ナ"]},
+  {"type": "multiple-choice", "direction": "romaji-to-kana", "prompt": "fu", "answer": "フ", "choices": ["フ", "ウ", "ワ", "ケ"]},
+  {"type": "multiple-choice", "direction": "romaji-to-kana", "prompt": "ne", "answer": "ネ", "choices": ["ネ", "レ", "メ", "テ"]}
 ]


### PR DESCRIPTION
## Summary
- create `lesson2.json` containing katakana questions
- rewrite `lesson2.js` to mirror lesson1 logic for typing + MCQ quizzes

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686ff5de32488331a50cf7273de62986