### PR TITLE
Add Lesson 2 Katakana data-driven quiz

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
     <button id="backBtn" class="btn back">Back</button>
   </div>
   <div id="lessonsView" class="wrapper">
+    <button id="lesson2Btn" class="btn lesson">Lesson 2: Katakana</button>
     <button id="lessonBackBtn" class="btn back">Back</button>
   </div>
   <div id="lessonView" class="wrapper" style="display:none;">

--- a/js/loader.js
+++ b/js/loader.js
@@ -4,6 +4,15 @@
   const lessonContent = document.getElementById('lessonContent');
   const quizBackBtn = document.getElementById('quizBackBtn');
   const lessonsView = document.getElementById('lessonsView');
+  const lesson2Btn = document.getElementById('lesson2Btn');
+
+  if (lesson2Btn) {
+    lesson2Btn.addEventListener('click', () => {
+      fetch('lessons/lesson2.json')
+        .then(res => res.json())
+        .then(data => loadLesson(data));
+    });
+  }
 
   window.startLesson = function(path) {
     fetch(path)

--- a/js/quiz.js
+++ b/js/quiz.js
@@ -250,6 +250,9 @@
 
   window.loadLesson = function(lessonData, opts = {}) {
     cleanup();
+    if (Array.isArray(lessonData)) {
+      lessonData = { questions: lessonData };
+    }
     state.lessonData = lessonData;
     state.viewEl = opts.viewEl || document.getElementById('lessonView');
     state.contentEl = opts.contentEl || document.getElementById('lessonContent');

--- a/lessons/lesson2.json
+++ b/lessons/lesson2.json
@@ -1,12 +1,15 @@
-[
-  {"type": "input", "direction": "kana-to-romaji", "prompt": "カ", "answer": "ka"},
-  {"type": "input", "direction": "kana-to-romaji", "prompt": "ツ", "answer": "tsu"},
-  {"type": "input", "direction": "kana-to-romaji", "prompt": "ノ", "answer": "no"},
-  {"type": "input", "direction": "romaji-to-kana", "prompt": "me", "answer": "メ"},
-  {"type": "input", "direction": "romaji-to-kana", "prompt": "ro", "answer": "ロ"},
-  {"type": "multiple-choice", "direction": "kana-to-romaji", "prompt": "セ", "answer": "se", "choices": ["se", "so", "sa", "ne"]},
-  {"type": "multiple-choice", "direction": "kana-to-romaji", "prompt": "ヨ", "answer": "yo", "choices": ["ya", "yu", "yo", "wa"]},
-  {"type": "multiple-choice", "direction": "romaji-to-kana", "prompt": "ta", "answer": "タ", "choices": ["チ", "タ", "テ", "ナ"]},
-  {"type": "multiple-choice", "direction": "romaji-to-kana", "prompt": "fu", "answer": "フ", "choices": ["フ", "ウ", "ワ", "ケ"]},
-  {"type": "multiple-choice", "direction": "romaji-to-kana", "prompt": "ne", "answer": "ネ", "choices": ["ネ", "レ", "メ", "テ"]}
-]
+{
+  "title": "Lesson 2: Katakana",
+  "questions": [
+    {"type": "input", "direction": "kana-to-romaji", "prompt": "カ", "answer": "ka"},
+    {"type": "input", "direction": "kana-to-romaji", "prompt": "ツ", "answer": "tsu"},
+    {"type": "input", "direction": "kana-to-romaji", "prompt": "ノ", "answer": "no"},
+    {"type": "input", "direction": "romaji-to-kana", "prompt": "me", "answer": "メ"},
+    {"type": "input", "direction": "romaji-to-kana", "prompt": "ro", "answer": "ロ"},
+    {"type": "multiple-choice", "direction": "kana-to-romaji", "prompt": "セ", "answer": "se", "choices": ["se", "so", "sa", "ne"]},
+    {"type": "multiple-choice", "direction": "kana-to-romaji", "prompt": "ヨ", "answer": "yo", "choices": ["ya", "yu", "yo", "wa"]},
+    {"type": "multiple-choice", "direction": "romaji-to-kana", "prompt": "ta", "answer": "タ", "choices": ["チ", "タ", "テ", "ナ"]},
+    {"type": "multiple-choice", "direction": "romaji-to-kana", "prompt": "fu", "answer": "フ", "choices": ["フ", "ウ", "ワ", "ケ"]},
+    {"type": "multiple-choice", "direction": "romaji-to-kana", "prompt": "ne", "answer": "ネ", "choices": ["ネ", "レ", "メ", "テ"]}
+  ]
+}


### PR DESCRIPTION
## Summary
- add Katakana lesson JSON with title and questions
- add Lesson 2 entry button to index
- load lesson 2 dynamically from loader
- support lessons as arrays or objects in quiz engine

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687006eed8848331b33ddc683af285c0