### PR TITLE
Add answer mode selector to lesson 2

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -270,3 +270,12 @@ body {
 .quiz-option.wrong {
   background: #c62828;
 }
+
+/* Mode selection view */
+#modeSelect label {
+  display: block;
+  margin: 1vh 0;
+}
+#modeSelect form {
+  margin-bottom: 2vh;
+}

--- a/index.html
+++ b/index.html
@@ -22,6 +22,16 @@
     <div id="lessonContent"></div>
     <button id="quizBackBtn" class="btn back">Back</button>
   </div>
+  <div id="modeSelect" class="wrapper" style="display:none;">
+    <h3 class="quiz-prompt">Choose your answer mode</h3>
+    <form id="modeForm">
+      <label><input type="radio" name="mode" value="mixed" checked /> Mixed</label>
+      <label><input type="radio" name="mode" value="input" /> Typing Only</label>
+      <label><input type="radio" name="mode" value="multiple-choice" /> Multiple Choice Only</label>
+    </form>
+    <button id="modeStartBtn" class="btn">Start</button>
+    <button id="modeBackBtn" class="btn back">Back</button>
+  </div>
   <div id="alphabetView" class="wrapper">
     <div class="alphabet-nav">
       <button id="hiraganaBtn" class="btn toggle active">Hiragana</button>

--- a/js/loader.js
+++ b/js/loader.js
@@ -5,12 +5,57 @@
   const quizBackBtn = document.getElementById('quizBackBtn');
   const lessonsView = document.getElementById('lessonsView');
   const lesson2Btn = document.getElementById('lesson2Btn');
+  const modeSelect = document.getElementById('modeSelect');
+  const modeForm = document.getElementById('modeForm');
+  const modeStartBtn = document.getElementById('modeStartBtn');
+  const modeBackBtn = document.getElementById('modeBackBtn');
+
+  function getSelectedMode() {
+    const checked = modeForm.querySelector('input[name="mode"]:checked');
+    return checked ? checked.value : 'mixed';
+  }
+
+  function showModeSelector() {
+    lessonsView.style.display = 'none';
+    modeSelect.style.display = 'flex';
+  }
+
+  function hideModeSelector() {
+    modeSelect.style.display = 'none';
+    lessonsView.style.display = 'flex';
+  }
 
   if (lesson2Btn) {
-    lesson2Btn.addEventListener('click', () => {
+    lesson2Btn.addEventListener('click', showModeSelector);
+  }
+
+  if (modeBackBtn) modeBackBtn.addEventListener('click', hideModeSelector);
+
+  if (modeStartBtn) {
+    modeStartBtn.addEventListener('click', () => {
       fetch('lessons/lesson2.json')
         .then(res => res.json())
-        .then(data => loadLesson(data));
+        .then(lesson => {
+          const selected = getSelectedMode();
+          const filtered = lesson.questions.filter(q =>
+            selected === 'mixed' ? true : q.type === selected
+          );
+          hideModeSelector();
+          loadLesson({ title: lesson.title, questions: filtered }, {
+            viewEl: lessonView,
+            contentEl: lessonContent,
+            backBtn: quizBackBtn,
+            onExit: () => {
+              lessonsView.style.display = 'flex';
+            },
+            selectedMode: selected === 'mixed' ? 'mix' : selected === 'multiple-choice' ? 'mcq' : 'input'
+          });
+        })
+        .catch(err => {
+          console.error('Failed to load lesson:', err);
+          lessonContent.textContent = 'Failed to load lesson.';
+          lessonView.style.display = 'flex';
+        });
     });
   }
 

--- a/js/quiz.js
+++ b/js/quiz.js
@@ -211,6 +211,8 @@
   }
 
   function startQuiz(mode = 'mix') {
+    if (mode === 'mixed') mode = 'mix';
+    if (mode === 'multiple-choice') mode = 'mcq';
     state.quizMode = mode;
     state.current = 0;
     state.retryIndex = 0;
@@ -272,6 +274,10 @@
     }
 
     if (state.viewEl) state.viewEl.style.display = 'flex';
-    showModeOptions();
+    if (opts.selectedMode) {
+      startQuiz(opts.selectedMode);
+    } else {
+      showModeOptions();
+    }
   };
 })();


### PR DESCRIPTION
## Summary
- add new mode selection form in HTML
- style mode selector section
- update loader to prompt for mode and filter questions before launch
- allow quiz engine to skip mode prompt when a mode is passed

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687015b6595c8331bff62cce19b6e72f