### PR TITLE
Fix submenu centering

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,34 +8,34 @@
   <link rel="stylesheet" href="css/portrait.css">
 </head>
 <body>
-  <div class="main-menu">
+  <div class="main-menu" id="mainMenu">
     <div class="header-title">Language &amp; Inspiration</div>
     <button class="menu-button learn">Learn Japanese</button>
     <button class="menu-button quote">Daily Quote</button>
   </div>
-  <div id="quotesView" class="wrapper">
-    <div class="header">Daily Quote</div>
+  <div id="quotesView" class="main-menu">
+    <div class="header-title">Daily Quote</div>
     <div class="quote-grid"></div>
-    <button id="backBtn" class="btn back">Back</button>
+    <button id="backBtn" class="menu-button back">Back</button>
   </div>
-  <div id="lessonsView" class="wrapper lesson-container">
-    <button id="lesson2Btn" class="btn lesson">Lesson 2: Katakana</button>
-    <button id="lessonBackBtn" class="btn back">Back</button>
+  <div id="lessonsView" class="main-menu lesson-container">
+    <button id="lesson2Btn" class="menu-button lesson">Lesson 2: Katakana</button>
+    <button id="lessonBackBtn" class="menu-button back">Back</button>
   </div>
-  <div id="lessonView" class="wrapper lesson-container" style="display:none;">
+  <div id="lessonView" class="main-menu lesson-container" style="display:none;">
     <div id="lessonContent"></div>
     <div id="debugInfo" class="debug-info" style="display:none;"></div>
-    <button id="quizBackBtn" class="btn back">Back</button>
+    <button id="quizBackBtn" class="menu-button back">Back</button>
   </div>
-  <div id="modeSelect" class="wrapper lesson-container" style="display:none;">
+  <div id="modeSelect" class="main-menu lesson-container" style="display:none;">
     <h3 class="quiz-prompt">Choose your answer mode</h3>
     <form id="modeForm">
       <label><input type="radio" name="mode" value="mixed" checked /> Mixed</label>
       <label><input type="radio" name="mode" value="input" /> Typing Only</label>
       <label><input type="radio" name="mode" value="multiple-choice" /> Multiple Choice Only</label>
     </form>
-    <button id="modeStartBtn" class="btn">Start</button>
-    <button id="modeBackBtn" class="btn back">Back</button>
+    <button id="modeStartBtn" class="menu-button">Start</button>
+    <button id="modeBackBtn" class="menu-button back">Back</button>
   </div>
   <div id="alphabetView" class="wrapper">
     <div class="alphabet-nav">

--- a/js/main.js
+++ b/js/main.js
@@ -1,7 +1,7 @@
 document.addEventListener('DOMContentLoaded', () => {
   const quoteBtn = document.querySelector('.quote');
   const learnBtn = document.querySelector('.learn');
-  const wrapper = document.querySelector('.wrapper');
+  const mainMenu = document.getElementById('mainMenu');
   const quotesView = document.getElementById('quotesView');
   const quoteGrid = document.querySelector('#quotesView .quote-grid');
   const lessonsView = document.getElementById('lessonsView');
@@ -60,7 +60,7 @@ document.addEventListener('DOMContentLoaded', () => {
     .then(data => {
       data.forEach(lesson => {
         const btn = document.createElement('button');
-        btn.className = 'btn lesson';
+        btn.className = 'menu-button lesson';
         btn.textContent = lesson.title;
         lessonsView.insertBefore(btn, lessonBackBtn);
         if (lesson.title === 'Alphabet') {
@@ -101,7 +101,7 @@ document.addEventListener('DOMContentLoaded', () => {
     .catch(err => console.error('Failed to load kanji:', err));
 
   function hideAllViews() {
-    wrapper.style.display = 'none';
+    mainMenu.style.display = 'none';
     quotesView.style.display = 'none';
     lessonsView.style.display = 'none';
     lessonView.style.display = 'none';
@@ -123,7 +123,7 @@ document.addEventListener('DOMContentLoaded', () => {
   backBtn.addEventListener('click', () => {
     document.querySelectorAll('.quote-card.flip').forEach(c => c.classList.remove('flip'));
     hideAllViews();
-    wrapper.style.display = 'flex';
+    mainMenu.style.display = 'flex';
   });
 
   learnBtn.addEventListener('click', (e) => {
@@ -134,7 +134,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   lessonBackBtn.addEventListener('click', () => {
     hideAllViews();
-    wrapper.style.display = 'flex';
+    mainMenu.style.display = 'flex';
   });
 
   alphabetBackBtn.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- apply `.main-menu` layout to Learn Japanese and Daily Quote screens
- align lesson/quiz mode views with vertically centered menu styling
- update scripts to target new `mainMenu` container and button classes

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687ba48809ec8331b1e21b87ba5e11f1