### PR TITLE
Implement multi-date daily table

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
     <div class="header-title">Language &amp; Inspiration</div>
     <button class="menu-button learn">Learn Japanese</button>
     <button class="menu-button quote">Daily Quote</button>
-    <button class="menu-button" onclick="showDailyTable()">Daily Table</button>
+    <button class="menu-button" onclick="showTableMenu()">Daily Table</button>
   </div>
   <div id="quotesView" class="main-menu">
     <div class="header-title">Daily Quote</div>

--- a/js/dailyTable.js
+++ b/js/dailyTable.js
@@ -1,37 +1,40 @@
-const dailyTableData = [
-  { category: "Must Do", task: "History", status: "❌" },
-  { category: "Must Do", task: "Languages", status: "❌" },
-  { category: "Must Do", task: "Education", status: "❌" },
-  { category: "Must Do", task: "About Me", status: "✅" },
-  { category: "Must Do", task: "Psychology", status: "❌" },
-];
-
-function showDailyTable() {
-  const container = document.getElementById("content");
-  const mainMenu = document.getElementById("mainMenu");
-  if (mainMenu) mainMenu.style.display = "none";
-  container.style.display = "flex";
+function showTableMenu() {
+  const container = document.getElementById('content');
+  const mainMenu = document.getElementById('mainMenu');
+  if (mainMenu) mainMenu.style.display = 'none';
+  container.style.display = 'flex';
   container.innerHTML = `
     <div class="header-title">Daily Table</div>
-    <div class="daily-table">
-      ${dailyTableData
-        .map(
-          (item) => `
-        <div class="daily-row">
-          <div class="cell category">${item.category}</div>
-          <div class="cell task">${item.task}</div>
-          <div class="cell status">${item.status}</div>
-        </div>
-      `
-        )
-        .join("")}
-      <button class="menu-button" onclick="goBack()">Back</button>
-    </div>
+    <button class="menu-button" onclick="loadTable('2025-07-18')">18/7/2025</button>
+    <button class="menu-button" onclick="loadTable('2025-07-19')">19/7/2025</button>
+    <button class="menu-button" onclick="loadTable('2025-07-20')">20/7/2025</button>
+    <button class="menu-button" onclick="goBack()">Back</button>
   `;
 }
 
+function loadTable(dateKey) {
+  fetch(`tables/${dateKey}.json`)
+    .then(res => res.json())
+    .then(data => {
+      const container = document.getElementById('content');
+      container.innerHTML = `
+        <div class="header-title">Table — ${dateKey.replace(/-/g, '/')}</div>
+        <div class="daily-table">
+          ${data.map(item => `
+            <div class="daily-row">
+              <div class="cell category">${item.category}</div>
+              <div class="cell task">${item.task}</div>
+              <div class="cell status">${item.status}</div>
+            </div>
+          `).join('')}
+        </div>
+        <button class="menu-button" onclick="showTableMenu()">Back</button>
+      `;
+    });
+}
+
 function goBack() {
-  const container = document.getElementById("content");
-  container.style.display = "none";
-  document.getElementById("mainMenu").style.display = "flex";
+  const container = document.getElementById('content');
+  container.style.display = 'none';
+  document.getElementById('mainMenu').style.display = 'flex';
 }

--- a/tables/2025-07-18.json
+++ b/tables/2025-07-18.json
@@ -1,0 +1,7 @@
+[
+  { "category": "Must Do", "task": "History", "status": "❌" },
+  { "category": "Must Do", "task": "Languages", "status": "❌" },
+  { "category": "Must Do", "task": "Education", "status": "❌" },
+  { "category": "Must Do", "task": "About Me", "status": "✅" },
+  { "category": "Must Do", "task": "Psychology", "status": "❌" }
+]

--- a/tables/2025-07-19.json
+++ b/tables/2025-07-19.json
@@ -1,0 +1,7 @@
+[
+  { "category": "Must Do", "task": "History", "status": "✅" },
+  { "category": "Must Do", "task": "Languages", "status": "❌" },
+  { "category": "Must Do", "task": "Education", "status": "✅" },
+  { "category": "Must Do", "task": "About Me", "status": "❌" },
+  { "category": "Must Do", "task": "Psychology", "status": "✅" }
+]

--- a/tables/2025-07-20.json
+++ b/tables/2025-07-20.json
@@ -1,0 +1,7 @@
+[
+  { "category": "Must Do", "task": "History", "status": "❌" },
+  { "category": "Must Do", "task": "Languages", "status": "✅" },
+  { "category": "Must Do", "task": "Education", "status": "❌" },
+  { "category": "Must Do", "task": "About Me", "status": "❌" },
+  { "category": "Must Do", "task": "Psychology", "status": "❌" }
+]


### PR DESCRIPTION
## Summary
- replace single daily table with menu page to load multiple dates
- create loader to fetch table data from JSON files
- update button on home page to open new daily table system
- add example table files for July 18-20, 2025

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687bbf353df08331942a4e981d8f749a