### PR TITLE
Update layout for 9:16 mobile viewport

### DIFF
--- a/css/portrait.css
+++ b/css/portrait.css
@@ -6,15 +6,26 @@
   -webkit-tap-highlight-color: transparent;
 }
 
-html, body {
-  width: 100%;
-  height: 100%;
-  background: #0e0e0e;
-  color: #f0f0f0;
+:root {
+  --content-width: 100vw;
+  --content-height: 100vh;
+  --aspect-ratio: 9 / 16;
+  --max-width: 430px;
+}
+
+html,
+body {
+  width: var(--content-width);
+  height: var(--content-height);
+  background-color: #0d0d0d;
+  color: #ffffff;
   font-family: system-ui, sans-serif;
-  font-size: 16px;
+  font-size: clamp(14px, 2.5vw, 18px);
   line-height: 1.6;
   overflow-x: hidden;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 
 /* ========== Container ========== */
@@ -27,6 +38,17 @@ html, body {
   flex-direction: column;
   gap: 1.75rem;
   justify-content: flex-start;
+}
+
+.viewport-container {
+  width: 100%;
+  max-width: 430px;
+  aspect-ratio: 9 / 16;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 1rem;
+  overflow-y: auto;
 }
 
 /* ========== Headings ========== */
@@ -119,7 +141,7 @@ input[type="text"]:focus {
   position: relative;
   width: 90%;
   max-width: 320px;
-  min-height: 180px;
+  min-height: 100px;
   perspective: 1000px;
   margin: 0 auto;
   cursor: pointer;
@@ -185,6 +207,7 @@ input[type="text"]:focus {
   padding: 1rem;
   background: #1a1a1a;
   border-radius: 0.75rem;
+  min-height: 100px;
   width: 90%;
   max-width: 320px;
   font-size: 0.95rem;
@@ -214,7 +237,7 @@ input[type="text"]:focus {
 
 @media (max-width: 430px) {
   .quote-card {
-    min-height: 200px;
+    min-height: 100px;
   }
 
   .quote-card-back {

--- a/css/style.css
+++ b/css/style.css
@@ -32,24 +32,29 @@ body {
   gap: 2rem;
 }
 
+
 .header-title {
-  font-size: 1.4rem;
+  font-size: 1.5rem;
+  margin-top: 2rem;
   text-align: center;
   letter-spacing: 0.1em;
   color: #ffffffcc;
   text-transform: uppercase;
 }
 
+
 .menu-button {
-  width: 100%;
-  max-width: 280px;
+  width: 80%;
+  max-width: 320px;
   padding: 1rem;
   font-size: 1.1rem;
-  background: rgba(255, 255, 255, 0.04);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  border-radius: 1rem;
-  backdrop-filter: blur(6px);
-  color: #f2f2f2;
+  background: #1a1a1a;
+  border: 1px solid #444;
+  border-radius: 1.25rem;
+  margin: 1rem 0;
+  color: white;
+  text-align: center;
+  box-shadow: 0 0 10px rgba(255, 255, 255, 0.05);
   transition: background 0.3s ease;
 }
 
@@ -136,7 +141,7 @@ body {
   position: relative;
   width: 90%;
   max-width: 320px;
-  min-height: 180px;
+  min-height: 100px;
   perspective: 1000px;
   margin: 0 auto;
   cursor: pointer;
@@ -293,7 +298,7 @@ body {
 
 @media (max-width: 430px) {
   .quote-card {
-    min-height: 200px;
+    min-height: 100px;
   }
 
   .quote-card-back {

--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
   <link rel="stylesheet" href="css/portrait.css">
 </head>
 <body>
+  <div class="viewport-container">
   <div class="main-menu" id="mainMenu">
     <div class="header-title">Language &amp; Inspiration</div>
     <button class="menu-button learn">Learn Japanese</button>
@@ -48,6 +49,7 @@
     <button id="alphabetBackBtn" class="btn back">Back</button>
   </div>
   <div id="content" class="main-menu" style="display:none;"></div>
+</div>
   <script src="js/main.js"></script>
   <script src="js/quiz.js"></script>
   <script src="js/loader.js"></script>


### PR DESCRIPTION
## Summary
- add viewport container and portrait root variables
- make menu buttons and card sizes suit iPhone 13
- hard-wrap page content in a portrait viewport container

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687bc0b81dd083319ef979cd251653fe