### PR TITLE
Expand daily quote layout

### DIFF
--- a/css/portrait.css
+++ b/css/portrait.css
@@ -48,13 +48,16 @@ body {
 }
 
 .viewport-container {
-  width: 100%;
-  max-width: 430px;
+  width: 100vw;
+  max-width: 100vw;
+  padding: 0;
+  margin: 0;
+  box-sizing: border-box;
+  overflow-x: hidden;
   aspect-ratio: 9 / 16;
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 1rem;
   overflow-y: auto;
   min-height: 100vh;
   height: 100dvh;
@@ -165,8 +168,15 @@ input[type="text"]:focus {
   gap: 1.5rem;
   padding: 2rem 1rem;
   width: 100%;
-  max-width: 430px;
+  max-width: none;
   margin: 0 auto;
+}
+
+.daily-quote-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
 }
 
 .quote-card {
@@ -282,11 +292,11 @@ input[type="text"]:focus {
 }
 
 .daily-quote-button {
-  width: 90%;
+  width: 90vw;
   max-width: 500px;
-  margin: 12px auto;
+  margin: 12px 0;
   padding: 16px 0;
-  font-size: 18px;
+  font-size: 1.1rem;
   text-align: center;
   border-radius: 30px;
   background-color: #1a1a1a;

--- a/css/style.css
+++ b/css/style.css
@@ -9,6 +9,18 @@ html, body {
   -webkit-overflow-scrolling: touch;
 }
 
+.viewport-container,
+#daily-quote-container,
+main,
+.container {
+  width: 100vw;
+  max-width: 100vw;
+  padding: 0;
+  margin: 0;
+  box-sizing: border-box;
+  overflow-x: hidden;
+}
+
 html {
   scroll-behavior: smooth;
   -webkit-overflow-scrolling: touch;
@@ -110,8 +122,15 @@ body {
   gap: 1.5rem;
   padding: 2rem 1rem;
   width: 100%;
-  max-width: 430px;
+  max-width: none;
   margin: 0 auto;
+}
+
+.daily-quote-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
 }
 
 @media (min-width: 800px) {
@@ -346,11 +365,11 @@ body {
 }
 
 .daily-quote-button {
-  width: 90%;
+  width: 90vw;
   max-width: 500px;
-  margin: 12px auto;
+  margin: 12px 0;
   padding: 16px 0;
-  font-size: 18px;
+  font-size: 1.1rem;
   text-align: center;
   border-radius: 30px;
   background-color: #1a1a1a;

--- a/index.html
+++ b/index.html
@@ -19,7 +19,9 @@
   </div>
   <div id="quotesView" class="main-menu">
     <div class="header-title">Daily Quote</div>
-    <div class="quote-grid"></div>
+    <div class="daily-quote-wrapper">
+      <div class="quote-grid"></div>
+    </div>
     <button id="backBtn" class="menu-button back">Back</button>
   </div>
   <div id="lessonsView" class="main-menu lesson-container">


### PR DESCRIPTION
## Summary
- allow entire screen width for daily quote section
- wrap quote grid in a new wrapper for flex centering
- widen daily quote buttons and grids in both stylesheets

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687d05da226883318372f609591de466