### PR TITLE
Apply unified wide-button style

### DIFF
--- a/css/portrait.css
+++ b/css/portrait.css
@@ -351,3 +351,23 @@ input[type="text"]:focus {
   }
 }
 
+.wide-button {
+  display: block;
+  width: 90%;
+  margin: 20px auto;
+  padding: 16px 24px;
+  font-size: 18px;
+  color: white;
+  background-color: #1c1c1e;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 24px;
+  text-align: center;
+  box-shadow: 0 0 12px rgba(255, 255, 255, 0.05);
+  transition: all 0.3s ease-in-out;
+}
+
+.wide-button:hover {
+  background-color: #2c2c2e;
+  transform: scale(1.02);
+}
+

--- a/css/style.css
+++ b/css/style.css
@@ -474,3 +474,23 @@ body {
   gap: 1rem;
   justify-content: center;
 }
+
+.wide-button {
+  display: block;
+  width: 90%;
+  margin: 20px auto;
+  padding: 16px 24px;
+  font-size: 18px;
+  color: white;
+  background-color: #1c1c1e;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 24px;
+  text-align: center;
+  box-shadow: 0 0 12px rgba(255, 255, 255, 0.05);
+  transition: all 0.3s ease-in-out;
+}
+
+.wide-button:hover {
+  background-color: #2c2c2e;
+  transform: scale(1.02);
+}

--- a/js/dailyTable.js
+++ b/js/dailyTable.js
@@ -42,8 +42,8 @@ function showTableMenu() {
   container.style.display = 'flex';
   container.innerHTML = `
     <div class="header-title">Daily Table</div>
-    <button class="menu-button" onclick="loadTable('2025-07-18')">18/7/2025</button>
-    <button class="menu-button" onclick="loadTable('2025-07-19')">19/7/2025</button>
+    <button class="wide-button" onclick="loadTable('2025-07-18')">18/7/2025</button>
+    <button class="wide-button" onclick="loadTable('2025-07-19')">19/7/2025</button>
     <button class="menu-button" onclick="goBack()">Back</button>
   `;
 }

--- a/js/main.js
+++ b/js/main.js
@@ -29,7 +29,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const text = entry.quote || entry;
 
         const card = document.createElement('div');
-        card.className = 'quote-card daily-quote-button';
+        card.className = 'quote-card daily-quote-button wide-button';
 
         const inner = document.createElement('div');
         inner.className = 'quote-card-inner';


### PR DESCRIPTION
## Summary
- add `wide-button` CSS class for consistent width/spacing
- apply the class in portrait stylesheet as well
- use `wide-button` for Daily Quote cards
- use `wide-button` for Daily Table date buttons

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687d3aa62ab48331b28c46d9b8699290