### PR TITLE
Apply wide button style to Learn Japanese section

### DIFF
--- a/css/portrait.css
+++ b/css/portrait.css
@@ -307,7 +307,7 @@ input[type="text"]:focus {
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding-top: 20px;
+  padding: 20px 0;
 }
 
 .learn-japanese-button {

--- a/css/style.css
+++ b/css/style.css
@@ -380,7 +380,7 @@ body {
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding-top: 20px;
+  padding: 20px 0;
 }
 
 .learn-japanese-button {

--- a/index.html
+++ b/index.html
@@ -25,8 +25,8 @@
     <button id="backBtn" class="menu-button back">Back</button>
   </div>
   <div id="lessonsView" class="main-menu lesson-container learn-japanese-container">
-    <button id="lesson2Btn" class="menu-button lesson learn-japanese-button">Lesson 2: Katakana</button>
-    <button id="lessonBackBtn" class="menu-button back learn-japanese-button">Back</button>
+    <button id="lesson2Btn" class="menu-button lesson learn-japanese-button wide-button">Lesson 2: Katakana</button>
+    <button id="lessonBackBtn" class="menu-button back learn-japanese-button wide-button">Back</button>
   </div>
   <div id="lessonView" class="main-menu lesson-container" style="display:none;">
     <div id="lessonContent"></div>

--- a/js/main.js
+++ b/js/main.js
@@ -60,7 +60,7 @@ document.addEventListener('DOMContentLoaded', () => {
     .then(data => {
       data.forEach(lesson => {
         const btn = document.createElement('button');
-        btn.className = 'menu-button lesson learn-japanese-button';
+        btn.className = 'menu-button lesson learn-japanese-button wide-button';
         btn.textContent = lesson.title;
         lessonsView.insertBefore(btn, lessonBackBtn);
         if (lesson.title === 'Alphabet') {


### PR DESCRIPTION
## Summary
- use the same `wide-button` class for lesson buttons
- give Learn Japanese container vertical padding to match Daily Quote style

## Testing
- `pytest`
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687d423b121883319f257e1c1ea21693