### PR TITLE
Simplify daily quote button layout

### DIFF
--- a/css/daily_quote.css
+++ b/css/daily_quote.css
@@ -1,22 +1,17 @@
-.daily-quote-button {
-  width: 90vw;
-  max-width: 95%;
-  margin: 24px auto;
+.quote-button {
+  width: 90%;
   padding: 24px;
+  background-color: rgba(255, 255, 255, 0.05);
+  border-radius: 20px;
+  font-size: 1.1rem;
+  line-height: 1.8em;
   text-align: center;
-  border-radius: 24px;
-  background-color: #1b1b1b;
   color: white;
-  font-size: 18px;
-  line-height: 1.7em;
-  white-space: normal;
-  word-break: break-word;
-  box-shadow: 0 0 10px rgba(255, 255, 255, 0.05);
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-  min-height: 120px;
+  margin: 20px auto;
+  box-shadow: 0 0 12px rgba(0, 0, 0, 0.4);
 }
 
-.daily-quote-button:hover {
+.quote-button:hover {
   transform: scale(1.02);
   box-shadow: 0 0 12px rgba(255, 255, 255, 0.1);
 }

--- a/js/main.js
+++ b/js/main.js
@@ -25,30 +25,11 @@ document.addEventListener('DOMContentLoaded', () => {
     .then(res => res.json())
     .then(data => {
       data.forEach((entry, idx) => {
-        const day = entry.day || idx + 1;
         const text = entry.quote || entry;
 
         const card = document.createElement('div');
-        card.className = 'quote-card daily-quote-button';
-
-        const inner = document.createElement('div');
-        inner.className = 'quote-card-inner';
-
-        const front = document.createElement('div');
-        front.className = 'quote-card-front';
-        front.textContent = `Day ${day}`;
-
-        const back = document.createElement('div');
-        back.className = 'quote-card-back';
-        back.textContent = text;
-
-        inner.appendChild(front);
-        inner.appendChild(back);
-        card.appendChild(inner);
-
-        card.addEventListener('click', () => {
-          card.classList.toggle('flipped');
-        });
+        card.className = 'quote-button';
+        card.textContent = text;
 
         quoteGrid.appendChild(card);
       });
@@ -121,7 +102,6 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   backBtn.addEventListener('click', () => {
-    document.querySelectorAll('.quote-card.flipped').forEach(c => c.classList.remove('flipped'));
     hideAllViews();
     mainMenu.style.display = 'flex';
   });


### PR DESCRIPTION
## Summary
- replace old `.daily-quote-button` styles with new `.quote-button`
- render quotes directly in the outer element and drop flip card layers
- simplify back button handler

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68821679197883318c480a7c751c2ffb