### PR TITLE
Fix daily quote centering and overflow

### DIFF
--- a/css/daily_quote.css
+++ b/css/daily_quote.css
@@ -11,6 +11,7 @@
   align-items: center;
   justify-content: center;
   box-sizing: border-box;
+  overflow-x: hidden;
 }
 
 .quote-entry {

--- a/css/style.css
+++ b/css/style.css
@@ -1,6 +1,7 @@
 
 html, body {
   width: 100vw;
+  max-width: 100vw;
   min-height: 100dvh;
   margin: 0;
   padding: 0;


### PR DESCRIPTION
## Summary
- adjust `.daily-quote-wrapper` to prevent horizontal overflow on mobile
- ensure html/body don't exceed viewport width

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6884e1d0fb448331a05473e02fd273ac