### PR TITLE
Add day-labeled quote cards

### DIFF
--- a/css/daily_quote.css
+++ b/css/daily_quote.css
@@ -37,11 +37,49 @@
 .quote-entry:hover {
   background: rgba(255, 255, 255, 0.08);
   transform: scale(1.015);
+  }
+
+  @media (max-width: 430px) {
+    .quote-entry {
+      font-size: 1.05rem;
+      padding: 1rem;
+    }
+  }
+
+.quote-card {
+  width: 100%;
+  max-width: 400px;
+  margin: 0 auto;
+  padding: 1.5rem;
+  border-radius: 1.75rem;
+  background: rgba(255, 255, 255, 0.05);
+  backdrop-filter: blur(10px);
+  box-shadow: 0 0 18px rgba(255, 255, 255, 0.05);
+  transition: transform 0.25s ease;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  text-align: center;
 }
 
-@media (max-width: 430px) {
-  .quote-entry {
-    font-size: 1.05rem;
-    padding: 1rem;
-  }
+.quote-card:hover {
+  transform: scale(1.02);
+}
+
+.quote-day {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #aaa;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.quote-entry {
+  font-size: 1.15rem;
+  font-weight: 500;
+  line-height: 1.6;
+  color: #fff;
+  white-space: pre-wrap;
+  word-wrap: break-word;
 }

--- a/js/main.js
+++ b/js/main.js
@@ -21,20 +21,30 @@ document.addEventListener('DOMContentLoaded', () => {
   let kanjiData = [];
   let activeSet = 'hiragana';
 
+  // Load and render quotes with labeled cards
   fetch('data/quotes.json')
     .then(res => res.json())
     .then(data => {
-      data.forEach((entry) => {
-        const text = entry.quote || entry;
+      const quoteGrid = document.querySelector('.quote-grid');
+      quoteGrid.innerHTML = '';
 
-        const div = document.createElement('div');
-        div.className = 'quote-entry';
-        div.textContent = text;
+      data.forEach(entry => {
+        const card = document.createElement('div');
+        card.className = 'quote-card';
 
-        quoteGrid.appendChild(div);
+        const dayLabel = document.createElement('div');
+        dayLabel.className = 'quote-day';
+        dayLabel.textContent = `Day ${entry.day}`;
+
+        const quoteText = document.createElement('div');
+        quoteText.className = 'quote-entry';
+        quoteText.textContent = entry.quote;
+
+        card.appendChild(dayLabel);
+        card.appendChild(quoteText);
+        quoteGrid.appendChild(card);
       });
-    })
-    .catch(err => console.error('Failed to load quotes:', err));
+    });
 
   fetch('data/lessons.json')
     .then(res => res.json())


### PR DESCRIPTION
## Summary
- render daily quotes using stylized cards and day labels
- add CSS for quote cards, day labels, and updated quote entry styling

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6884e4c0a2088331a8ca0c95cebbbf0c