### PR TITLE
Add Learn Japanese lessons view and toggle logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,15 @@
     <button class="menu-button wip-button" disabled>Games (Coming Soon)</button>
     <button class="menu-button wip-button" disabled>Coding (Coming Soon)</button>
   </div>
+  <div id="lessonsView" class="main-menu learn-japanese-container" style="display: none;">
+    <div class="header-title">Learn Japanese</div>
+
+    <button class="menu-button wide-button" id="alphabetBtn">Alphabet</button>
+    <!-- Future lessons go below -->
+    <!-- <button class="menu-button wide-button" id="lesson1Btn">Lesson 1</button> -->
+
+    <button id="lessonBackBtn" class="menu-button back wide-button">Back</button>
+  </div>
   <div id="quotesView" class="main-menu">
     <div class="header-title">Daily Quote</div>
     <div class="daily-quote-wrapper">

--- a/js/main.js
+++ b/js/main.js
@@ -1,10 +1,12 @@
 document.addEventListener('DOMContentLoaded', () => {
   const quoteBtn = document.querySelector('.quote');
-  const learnBtn = document.querySelector('.learn');
+  const learnJapaneseBtn = document.querySelector('.learn');
   const mainMenu = document.getElementById('mainMenu');
   const quotesView = document.getElementById('quotesView');
   const quoteGrid = document.querySelector('#quotesView .quote-grid');
   const backBtn = document.getElementById('backBtn');
+  const lessonsView = document.getElementById('lessonsView');
+  const lessonBackBtn = document.getElementById('lessonBackBtn');
 
   // Load and render daily quotes
   fetch('data/quotes.json')
@@ -29,6 +31,7 @@ document.addEventListener('DOMContentLoaded', () => {
   function hideAllViews() {
     mainMenu.style.display = 'none';
     quotesView.style.display = 'none';
+    lessonsView.style.display = 'none';
   }
 
   quoteBtn.addEventListener('click', e => {
@@ -36,6 +39,16 @@ document.addEventListener('DOMContentLoaded', () => {
     hideAllViews();
     quotesView.style.display = 'flex';
     quotesView.scrollTop = 0;
+  });
+
+  learnJapaneseBtn.addEventListener('click', () => {
+    mainMenu.style.display = 'none';
+    lessonsView.style.display = 'flex';
+  });
+
+  lessonBackBtn.addEventListener('click', () => {
+    lessonsView.style.display = 'none';
+    mainMenu.style.display = 'flex';
   });
 
   backBtn.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- add Learn Japanese lessons view container
- toggle the lessons view with Learn Japanese button and back button

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68850c1bce10833193e30841d2cb7573