### PR TITLE
Add Dakuten + Handakuten Katakana

### DIFF
--- a/data/katakana.json
+++ b/data/katakana.json
@@ -4,44 +4,83 @@
   { "kana": "ウ", "romaji": "u" },
   { "kana": "エ", "romaji": "e" },
   { "kana": "オ", "romaji": "o" },
+
   { "kana": "カ", "romaji": "ka" },
   { "kana": "キ", "romaji": "ki" },
   { "kana": "ク", "romaji": "ku" },
   { "kana": "ケ", "romaji": "ke" },
   { "kana": "コ", "romaji": "ko" },
+
+  { "kana": "ガ", "romaji": "ga" },
+  { "kana": "ギ", "romaji": "gi" },
+  { "kana": "グ", "romaji": "gu" },
+  { "kana": "ゲ", "romaji": "ge" },
+  { "kana": "ゴ", "romaji": "go" },
+
   { "kana": "サ", "romaji": "sa" },
   { "kana": "シ", "romaji": "shi" },
   { "kana": "ス", "romaji": "su" },
   { "kana": "セ", "romaji": "se" },
   { "kana": "ソ", "romaji": "so" },
+
+  { "kana": "ザ", "romaji": "za" },
+  { "kana": "ジ", "romaji": "ji" },
+  { "kana": "ズ", "romaji": "zu" },
+  { "kana": "ゼ", "romaji": "ze" },
+  { "kana": "ゾ", "romaji": "zo" },
+
   { "kana": "タ", "romaji": "ta" },
   { "kana": "チ", "romaji": "chi" },
   { "kana": "ツ", "romaji": "tsu" },
   { "kana": "テ", "romaji": "te" },
   { "kana": "ト", "romaji": "to" },
+
+  { "kana": "ダ", "romaji": "da" },
+  { "kana": "ヂ", "romaji": "ji" },
+  { "kana": "ヅ", "romaji": "zu" },
+  { "kana": "デ", "romaji": "de" },
+  { "kana": "ド", "romaji": "do" },
+
   { "kana": "ナ", "romaji": "na" },
   { "kana": "ニ", "romaji": "ni" },
   { "kana": "ヌ", "romaji": "nu" },
   { "kana": "ネ", "romaji": "ne" },
   { "kana": "ノ", "romaji": "no" },
+
   { "kana": "ハ", "romaji": "ha" },
   { "kana": "ヒ", "romaji": "hi" },
   { "kana": "フ", "romaji": "fu" },
   { "kana": "ヘ", "romaji": "he" },
   { "kana": "ホ", "romaji": "ho" },
+
+  { "kana": "バ", "romaji": "ba" },
+  { "kana": "ビ", "romaji": "bi" },
+  { "kana": "ブ", "romaji": "bu" },
+  { "kana": "ベ", "romaji": "be" },
+  { "kana": "ボ", "romaji": "bo" },
+
+  { "kana": "パ", "romaji": "pa" },
+  { "kana": "ピ", "romaji": "pi" },
+  { "kana": "プ", "romaji": "pu" },
+  { "kana": "ペ", "romaji": "pe" },
+  { "kana": "ポ", "romaji": "po" },
+
   { "kana": "マ", "romaji": "ma" },
   { "kana": "ミ", "romaji": "mi" },
   { "kana": "ム", "romaji": "mu" },
   { "kana": "メ", "romaji": "me" },
   { "kana": "モ", "romaji": "mo" },
+
   { "kana": "ヤ", "romaji": "ya" },
   { "kana": "ユ", "romaji": "yu" },
   { "kana": "ヨ", "romaji": "yo" },
+
   { "kana": "ラ", "romaji": "ra" },
   { "kana": "リ", "romaji": "ri" },
   { "kana": "ル", "romaji": "ru" },
   { "kana": "レ", "romaji": "re" },
   { "kana": "ロ", "romaji": "ro" },
+
   { "kana": "ワ", "romaji": "wa" },
   { "kana": "ヲ", "romaji": "wo" },
   { "kana": "ン", "romaji": "n" }


### PR DESCRIPTION
## Summary
- add the full katakana dataset including dakuten and handakuten characters

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688527a555248331b1dd844d35d89d0f