### PR TITLE
Add Kanji learning page

### DIFF
--- a/css/kanji.css
+++ b/css/kanji.css
@@ -1,0 +1,24 @@
+.kanji-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  gap: 1rem;
+  padding: 2rem 1rem;
+}
+
+.kanji-card {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  backdrop-filter: blur(8px);
+  border-radius: 1rem;
+  padding: 1rem;
+  text-align: center;
+  color: white;
+  box-shadow: 0 0 10px rgba(255,255,255,0.04);
+  font-size: 1.1rem;
+  transition: all 0.2s ease;
+}
+
+.kanji-card .kanji {
+  font-size: 2.5rem;
+  margin-bottom: 0.5rem;
+}

--- a/data/kanji.json
+++ b/data/kanji.json
@@ -1,0 +1,62 @@
+[
+  {
+    "kanji": "日",
+    "meanings": ["day", "sun"],
+    "onyomi": ["ニチ", "ジツ"],
+    "kunyomi": ["ひ", "び", "か"]
+  },
+  {
+    "kanji": "月",
+    "meanings": ["month", "moon"],
+    "onyomi": ["ゲツ", "ガツ"],
+    "kunyomi": ["つき"]
+  },
+  {
+    "kanji": "火",
+    "meanings": ["fire"],
+    "onyomi": ["カ"],
+    "kunyomi": ["ひ"]
+  },
+  {
+    "kanji": "水",
+    "meanings": ["water"],
+    "onyomi": ["スイ"],
+    "kunyomi": ["みず"]
+  },
+  {
+    "kanji": "木",
+    "meanings": ["tree", "wood"],
+    "onyomi": ["モク", "ボク"],
+    "kunyomi": ["き"]
+  },
+  {
+    "kanji": "金",
+    "meanings": ["gold", "money"],
+    "onyomi": ["キン", "コン"],
+    "kunyomi": ["かね"]
+  },
+  {
+    "kanji": "土",
+    "meanings": ["earth", "soil"],
+    "onyomi": ["ド", "ト"],
+    "kunyomi": ["つち"]
+  },
+  {
+    "kanji": "山",
+    "meanings": ["mountain"],
+    "onyomi": ["サン"],
+    "kunyomi": ["やま"]
+  },
+  {
+    "kanji": "川",
+    "meanings": ["river"],
+    "onyomi": ["セン"],
+    "kunyomi": ["かわ"]
+  },
+  {
+    "kanji": "田",
+    "meanings": ["rice field"],
+    "onyomi": ["デン"],
+    "kunyomi": ["た"]
+  }
+]

--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
   <link rel="stylesheet" href="css/daily_quote.css">
   <link rel="stylesheet" href="css/alphabet.css">
   <link rel="stylesheet" href="css/learn_japanese.css">
+  <link rel="stylesheet" href="css/kanji.css">
 </head>
 <body>
   <div class="viewport-container">
@@ -23,7 +24,7 @@
 
   <button class="menu-button wide-button" id="hiraganaBtn">Hiragana</button>
   <button class="menu-button wide-button" id="katakanaBtn">Katakana</button>
-    <button class="menu-button wide-button wip-button" id="kanjiBtn">Kanji (Coming Soon)</button>
+  <button class="menu-button wide-button" id="kanjiBtn">Kanji</button>
     <!-- Future lessons go below -->
     <!-- <button class="menu-button wide-button" id="lesson1Btn">Lesson 1</button> -->
 
@@ -46,9 +47,15 @@
     <div id="katakanaGrid" class="alphabet-grid"></div>
     <button class="menu-button back" onclick="returnToLearnJapanese()">Back</button>
   </div>
+  <div id="kanjiView" class="main-menu" style="display:none;">
+    <div class="header-title">Kanji</div>
+    <div id="kanjiGrid" class="kanji-grid"></div>
+    <button id="kanjiBackBtn" class="btn back">Back</button>
+  </div>
   <div id="content" class="main-menu" style="display:none;"></div>
 </div>
   <script src="js/main.js"></script>
   <script src="js/alphabet.js"></script>
+  <script src="js/kanji.js"></script>
 </body>
 </html>

--- a/js/kanji.js
+++ b/js/kanji.js
@@ -1,0 +1,18 @@
+fetch('data/kanji.json')
+  .then(res => res.json())
+  .then(data => {
+    const grid = document.getElementById('kanjiGrid');
+    data.forEach(entry => {
+      const card = document.createElement('div');
+      card.className = 'kanji-card';
+      card.innerHTML = `
+        <div class="kanji">${entry.kanji}</div>
+        <div class="meaning">${entry.meanings.join(', ')}</div>
+        <div class="reading">
+          <strong>On:</strong> ${entry.onyomi.join(', ')}<br>
+          <strong>Kun:</strong> ${entry.kunyomi.join(', ')}
+        </div>
+      `;
+      grid.appendChild(card);
+    });
+  });

--- a/js/main.js
+++ b/js/main.js
@@ -11,6 +11,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const katakanaBtn = document.getElementById('katakanaBtn');
   const katakanaGrid = document.getElementById('katakanaGrid');
   const kanjiBtn = document.getElementById('kanjiBtn');
+  const kanjiView = document.getElementById('kanjiView');
+  const kanjiBackBtn = document.getElementById('kanjiBackBtn');
 
   // Load and render daily quotes
   fetch('data/quotes.json')
@@ -77,14 +79,15 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
-  // Show placeholder message for Kanji
-  if (kanjiBtn) {
+  if (kanjiBtn && kanjiView && kanjiBackBtn) {
     kanjiBtn.addEventListener('click', () => {
-      lessonsView.classList.add('hidden');
-      const grid = document.getElementById('katakanaView');
-      grid.classList.remove('hidden');
-      const inner = document.getElementById('katakanaGrid');
-      inner.innerHTML = '<div class="header">Kanji support coming soon...</div>';
+      hideAllViews();
+      kanjiView.style.display = 'flex';
+    });
+
+    kanjiBackBtn.addEventListener('click', () => {
+      kanjiView.style.display = 'none';
+      document.getElementById('lessonsView').style.display = 'flex';
     });
   }
 


### PR DESCRIPTION
## Summary
- create a JSON dataset for introductory kanji
- add styles for kanji cards and grid
- load kanji data with new script
- show kanji page from the Learn Japanese menu

## Testing
- `npm test` *(fails: no such command)*

------
https://chatgpt.com/codex/tasks/task_e_68852a6b06ec83319070670566cd8310