### PR TITLE
Expand hiragana lesson coverage

### DIFF
--- a/data/lessons/hiragana_lesson1.json
+++ b/data/lessons/hiragana_lesson1.json
@@ -1,32 +1,1146 @@
 [
   {
     "type": "hiragana-to-romaji",
-    "prompt": "た",
-    "options": ["Ha", "Mo", "Ta", "Ku"],
-    "answer": "Ta"
+    "prompt": "も",
+    "options": [
+      "Mo",
+      "Ge",
+      "Ra",
+      "Ta"
+    ],
+    "answer": "Mo"
   },
   {
     "type": "romaji-to-hiragana",
-    "prompt": "mo",
-    "options": ["さ", "も", "ひ", "ら"],
-    "answer": "も"
+    "prompt": "ji",
+    "options": [
+      "び",
+      "で",
+      "も",
+      "じ"
+    ],
+    "answer": "じ"
   },
   {
     "type": "hiragana-to-romaji",
-    "prompt": "き",
-    "options": ["Ki", "Shi", "Sa", "Ko"],
-    "answer": "Ki"
+    "prompt": "みゃ",
+    "options": [
+      "Mya",
+      "Chu",
+      "Su",
+      "U"
+    ],
+    "answer": "Mya"
   },
   {
     "type": "romaji-to-hiragana",
-    "prompt": "su",
-    "options": ["す", "し", "さ", "そ"],
-    "answer": "す"
+    "prompt": "he",
+    "options": [
+      "い",
+      "は",
+      "ひゃ",
+      "へ"
+    ],
+    "answer": "へ"
+  },
+  {
+    "type": "hiragana-to-romaji",
+    "prompt": "や",
+    "options": [
+      "De",
+      "Mo",
+      "Ya",
+      "Fu"
+    ],
+    "answer": "Ya"
+  },
+  {
+    "type": "romaji-to-hiragana",
+    "prompt": "gyo",
+    "options": [
+      "ぱ",
+      "は",
+      "ぽ",
+      "ぎょ"
+    ],
+    "answer": "ぎょ"
+  },
+  {
+    "type": "hiragana-to-romaji",
+    "prompt": "と",
+    "options": [
+      "Chi",
+      "Ho",
+      "Mi",
+      "To"
+    ],
+    "answer": "To"
+  },
+  {
+    "type": "romaji-to-hiragana",
+    "prompt": "nya",
+    "options": [
+      "れ",
+      "り",
+      "りょ",
+      "にゃ"
+    ],
+    "answer": "にゃ"
+  },
+  {
+    "type": "hiragana-to-romaji",
+    "prompt": "ま",
+    "options": [
+      "Ma",
+      "Cho",
+      "Ta",
+      "Do"
+    ],
+    "answer": "Ma"
+  },
+  {
+    "type": "romaji-to-hiragana",
+    "prompt": "kyo",
+    "options": [
+      "みゃ",
+      "よ",
+      "きょ",
+      "じ"
+    ],
+    "answer": "きょ"
+  },
+  {
+    "type": "hiragana-to-romaji",
+    "prompt": "よ",
+    "options": [
+      "Yo",
+      "Mya",
+      "So",
+      "Kyu"
+    ],
+    "answer": "Yo"
+  },
+  {
+    "type": "romaji-to-hiragana",
+    "prompt": "pyo",
+    "options": [
+      "ぱ",
+      "りょ",
+      "ぜ",
+      "ぴょ"
+    ],
+    "answer": "ぴょ"
+  },
+  {
+    "type": "hiragana-to-romaji",
+    "prompt": "ぎ",
+    "options": [
+      "Ho",
+      "Ji",
+      "Myu",
+      "Gi"
+    ],
+    "answer": "Gi"
+  },
+  {
+    "type": "romaji-to-hiragana",
+    "prompt": "nyo",
+    "options": [
+      "にょ",
+      "ぜ",
+      "が",
+      "ぎょ"
+    ],
+    "answer": "にょ"
+  },
+  {
+    "type": "hiragana-to-romaji",
+    "prompt": "ど",
+    "options": [
+      "O",
+      "Do",
+      "Be",
+      "Bo"
+    ],
+    "answer": "Do"
+  },
+  {
+    "type": "romaji-to-hiragana",
+    "prompt": "yu",
+    "options": [
+      "せ",
+      "ゆ",
+      "りゃ",
+      "る"
+    ],
+    "answer": "ゆ"
+  },
+  {
+    "type": "hiragana-to-romaji",
+    "prompt": "お",
+    "options": [
+      "Bo",
+      "Sa",
+      "O",
+      "Fu"
+    ],
+    "answer": "O"
+  },
+  {
+    "type": "romaji-to-hiragana",
+    "prompt": "ki",
+    "options": [
+      "ぱ",
+      "き",
+      "にゃ",
+      "ご"
+    ],
+    "answer": "き"
+  },
+  {
+    "type": "hiragana-to-romaji",
+    "prompt": "れ",
+    "options": [
+      "Ma",
+      "Ba",
+      "Hi",
+      "Re"
+    ],
+    "answer": "Re"
+  },
+  {
+    "type": "romaji-to-hiragana",
+    "prompt": "ho",
+    "options": [
+      "む",
+      "ほ",
+      "ん",
+      "ま"
+    ],
+    "answer": "ほ"
+  },
+  {
+    "type": "hiragana-to-romaji",
+    "prompt": "す",
+    "options": [
+      "Su",
+      "Cho",
+      "Se",
+      "Zu"
+    ],
+    "answer": "Su"
+  },
+  {
+    "type": "romaji-to-hiragana",
+    "prompt": "bi",
+    "options": [
+      "も",
+      "ね",
+      "び",
+      "じゃ"
+    ],
+    "answer": "び"
+  },
+  {
+    "type": "hiragana-to-romaji",
+    "prompt": "ちゃ",
+    "options": [
+      "Bi",
+      "Fu",
+      "Cha",
+      "Me"
+    ],
+    "answer": "Cha"
+  },
+  {
+    "type": "romaji-to-hiragana",
+    "prompt": "za",
+    "options": [
+      "づ",
+      "りゅ",
+      "ざ",
+      "ぢ"
+    ],
+    "answer": "ざ"
+  },
+  {
+    "type": "hiragana-to-romaji",
+    "prompt": "ば",
+    "options": [
+      "Do",
+      "Ke",
+      "Shu",
+      "Ba"
+    ],
+    "answer": "Ba"
+  },
+  {
+    "type": "romaji-to-hiragana",
+    "prompt": "u",
+    "options": [
+      "ぬ",
+      "う",
+      "ら",
+      "て"
+    ],
+    "answer": "う"
+  },
+  {
+    "type": "hiragana-to-romaji",
+    "prompt": "ろ",
+    "options": [
+      "Pa",
+      "Nya",
+      "Pya",
+      "Ro"
+    ],
+    "answer": "Ro"
+  },
+  {
+    "type": "romaji-to-hiragana",
+    "prompt": "shu",
+    "options": [
+      "しゅ",
+      "じ",
+      "へ",
+      "さ"
+    ],
+    "answer": "しゅ"
+  },
+  {
+    "type": "hiragana-to-romaji",
+    "prompt": "あ",
+    "options": [
+      "Ru",
+      "Nya",
+      "A",
+      "Hya"
+    ],
+    "answer": "A"
+  },
+  {
+    "type": "romaji-to-hiragana",
+    "prompt": "pi",
+    "options": [
+      "ぴ",
+      "ぎ",
+      "ま",
+      "げ"
+    ],
+    "answer": "ぴ"
+  },
+  {
+    "type": "hiragana-to-romaji",
+    "prompt": "りょ",
+    "options": [
+      "Ryo",
+      "Ji",
+      "Ne",
+      "Ju"
+    ],
+    "answer": "Ryo"
+  },
+  {
+    "type": "romaji-to-hiragana",
+    "prompt": "gyu",
+    "options": [
+      "みょ",
+      "ぷ",
+      "ぎゅ",
+      "に"
+    ],
+    "answer": "ぎゅ"
+  },
+  {
+    "type": "hiragana-to-romaji",
+    "prompt": "ひゅ",
+    "options": [
+      "Hyu",
+      "He",
+      "Pyo",
+      "Ro"
+    ],
+    "answer": "Hyu"
+  },
+  {
+    "type": "romaji-to-hiragana",
+    "prompt": "pya",
+    "options": [
+      "や",
+      "ぴゃ",
+      "け",
+      "く"
+    ],
+    "answer": "ぴゃ"
+  },
+  {
+    "type": "hiragana-to-romaji",
+    "prompt": "ひゃ",
+    "options": [
+      "De",
+      "Ki",
+      "Hya",
+      "Yo"
+    ],
+    "answer": "Hya"
+  },
+  {
+    "type": "romaji-to-hiragana",
+    "prompt": "bya",
+    "options": [
+      "びゃ",
+      "よ",
+      "ざ",
+      "ゆ"
+    ],
+    "answer": "びゃ"
+  },
+  {
+    "type": "hiragana-to-romaji",
+    "prompt": "じゅ",
+    "options": [
+      "Byo",
+      "Ke",
+      "Kyo",
+      "Ju"
+    ],
+    "answer": "Ju"
+  },
+  {
+    "type": "romaji-to-hiragana",
+    "prompt": "be",
+    "options": [
+      "べ",
+      "じゅ",
+      "ぴゃ",
+      "ね"
+    ],
+    "answer": "べ"
+  },
+  {
+    "type": "hiragana-to-romaji",
+    "prompt": "ご",
+    "options": [
+      "Pe",
+      "Hyo",
+      "Go",
+      "Te"
+    ],
+    "answer": "Go"
+  },
+  {
+    "type": "romaji-to-hiragana",
+    "prompt": "nu",
+    "options": [
+      "ひゃ",
+      "ぬ",
+      "ちゃ",
+      "ば"
+    ],
+    "answer": "ぬ"
+  },
+  {
+    "type": "hiragana-to-romaji",
+    "prompt": "ぴゅ",
+    "options": [
+      "Ne",
+      "Pyu",
+      "Hyo",
+      "Mi"
+    ],
+    "answer": "Pyu"
+  },
+  {
+    "type": "romaji-to-hiragana",
+    "prompt": "mu",
+    "options": [
+      "みゃ",
+      "む",
+      "え",
+      "にゃ"
+    ],
+    "answer": "む"
+  },
+  {
+    "type": "hiragana-to-romaji",
+    "prompt": "きゃ",
+    "options": [
+      "Chi",
+      "Se",
+      "Kya",
+      "U"
+    ],
+    "answer": "Kya"
+  },
+  {
+    "type": "romaji-to-hiragana",
+    "prompt": "rya",
+    "options": [
+      "ぎゃ",
+      "み",
+      "りゃ",
+      "け"
+    ],
+    "answer": "りゃ"
+  },
+  {
+    "type": "hiragana-to-romaji",
+    "prompt": "ひょ",
+    "options": [
+      "Ba",
+      "Ro",
+      "Ma",
+      "Hyo"
+    ],
+    "answer": "Hyo"
+  },
+  {
+    "type": "romaji-to-hiragana",
+    "prompt": "ta",
+    "options": [
+      "ゆ",
+      "しゃ",
+      "ぼ",
+      "た"
+    ],
+    "answer": "た"
+  },
+  {
+    "type": "hiragana-to-romaji",
+    "prompt": "げ",
+    "options": [
+      "Ge",
+      "Byu",
+      "Do",
+      "Ha"
+    ],
+    "answer": "Ge"
+  },
+  {
+    "type": "romaji-to-hiragana",
+    "prompt": "ke",
+    "options": [
+      "せ",
+      "きゃ",
+      "ちょ",
+      "け"
+    ],
+    "answer": "け"
+  },
+  {
+    "type": "hiragana-to-romaji",
+    "prompt": "びょ",
+    "options": [
+      "Byo",
+      "Hyo",
+      "No",
+      "Zu"
+    ],
+    "answer": "Byo"
+  },
+  {
+    "type": "romaji-to-hiragana",
+    "prompt": "wa",
+    "options": [
+      "も",
+      "りゅ",
+      "わ",
+      "な"
+    ],
+    "answer": "わ"
+  },
+  {
+    "type": "hiragana-to-romaji",
+    "prompt": "み",
+    "options": [
+      "Pu",
+      "Za",
+      "Mi",
+      "Ji"
+    ],
+    "answer": "Mi"
+  },
+  {
+    "type": "romaji-to-hiragana",
+    "prompt": "de",
+    "options": [
+      "で",
+      "と",
+      "む",
+      "ぎょ"
+    ],
+    "answer": "で"
+  },
+  {
+    "type": "hiragana-to-romaji",
+    "prompt": "こ",
+    "options": [
+      "Hyo",
+      "Cha",
+      "Ko",
+      "Ne"
+    ],
+    "answer": "Ko"
+  },
+  {
+    "type": "romaji-to-hiragana",
+    "prompt": "chu",
+    "options": [
+      "しょ",
+      "か",
+      "ちゅ",
+      "も"
+    ],
+    "answer": "ちゅ"
+  },
+  {
+    "type": "hiragana-to-romaji",
+    "prompt": "ぱ",
+    "options": [
+      "Ri",
+      "Zu",
+      "Byo",
+      "Pa"
+    ],
+    "answer": "Pa"
+  },
+  {
+    "type": "romaji-to-hiragana",
+    "prompt": "ze",
+    "options": [
+      "き",
+      "は",
+      "ぜ",
+      "ち"
+    ],
+    "answer": "ぜ"
+  },
+  {
+    "type": "hiragana-to-romaji",
+    "prompt": "ちょ",
+    "options": [
+      "Ki",
+      "Su",
+      "Jo",
+      "Cho"
+    ],
+    "answer": "Cho"
+  },
+  {
+    "type": "romaji-to-hiragana",
+    "prompt": "byu",
+    "options": [
+      "びゅ",
+      "や",
+      "ざ",
+      "ひ"
+    ],
+    "answer": "びゅ"
+  },
+  {
+    "type": "hiragana-to-romaji",
+    "prompt": "ぐ",
+    "options": [
+      "Ta",
+      "Gu",
+      "Pi",
+      "Myo"
+    ],
+    "answer": "Gu"
+  },
+  {
+    "type": "romaji-to-hiragana",
+    "prompt": "ja",
+    "options": [
+      "ら",
+      "じゃ",
+      "び",
+      "びゅ"
+    ],
+    "answer": "じゃ"
+  },
+  {
+    "type": "hiragana-to-romaji",
+    "prompt": "そ",
+    "options": [
+      "Ho",
+      "Ja",
+      "Tsu",
+      "So"
+    ],
+    "answer": "So"
+  },
+  {
+    "type": "romaji-to-hiragana",
+    "prompt": "zo",
+    "options": [
+      "ぞ",
+      "ひょ",
+      "しょ",
+      "た"
+    ],
+    "answer": "ぞ"
+  },
+  {
+    "type": "hiragana-to-romaji",
+    "prompt": "しゃ",
+    "options": [
+      "Myu",
+      "Sha",
+      "Za",
+      "Mya"
+    ],
+    "answer": "Sha"
+  },
+  {
+    "type": "romaji-to-hiragana",
+    "prompt": "te",
+    "options": [
+      "みょ",
+      "て",
+      "き",
+      "れ"
+    ],
+    "answer": "て"
+  },
+  {
+    "type": "hiragana-to-romaji",
+    "prompt": "ぼ",
+    "options": [
+      "Chu",
+      "Hi",
+      "Bo",
+      "Kya"
+    ],
+    "answer": "Bo"
+  },
+  {
+    "type": "romaji-to-hiragana",
+    "prompt": "ku",
+    "options": [
+      "びゅ",
+      "い",
+      "ら",
+      "く"
+    ],
+    "answer": "く"
+  },
+  {
+    "type": "hiragana-to-romaji",
+    "prompt": "づ",
+    "options": [
+      "O",
+      "Sha",
+      "Zu",
+      "Ku"
+    ],
+    "answer": "Zu"
+  },
+  {
+    "type": "romaji-to-hiragana",
+    "prompt": "zu",
+    "options": [
+      "しゃ",
+      "づ",
+      "ず",
+      "しょ"
+    ],
+    "answer": "ず"
+  },
+  {
+    "type": "hiragana-to-romaji",
+    "prompt": "ぽ",
+    "options": [
+      "Ma",
+      "Po",
+      "Ju",
+      "Ri"
+    ],
+    "answer": "Po"
+  },
+  {
+    "type": "romaji-to-hiragana",
+    "prompt": "ka",
+    "options": [
+      "ぷ",
+      "み",
+      "か",
+      "びょ"
+    ],
+    "answer": "か"
+  },
+  {
+    "type": "hiragana-to-romaji",
+    "prompt": "せ",
+    "options": [
+      "Bya",
+      "Ryu",
+      "Se",
+      "E"
+    ],
+    "answer": "Se"
+  },
+  {
+    "type": "romaji-to-hiragana",
+    "prompt": "ra",
+    "options": [
+      "ら",
+      "ぶ",
+      "ど",
+      "ぴゅ"
+    ],
+    "answer": "ら"
+  },
+  {
+    "type": "hiragana-to-romaji",
+    "prompt": "な",
+    "options": [
+      "Na",
+      "Sa",
+      "De",
+      "Pe"
+    ],
+    "answer": "Na"
+  },
+  {
+    "type": "romaji-to-hiragana",
+    "prompt": "tsu",
+    "options": [
+      "しゃ",
+      "ちょ",
+      "づ",
+      "つ"
+    ],
+    "answer": "つ"
+  },
+  {
+    "type": "hiragana-to-romaji",
+    "prompt": "りゅ",
+    "options": [
+      "Ba",
+      "Bi",
+      "Rya",
+      "Ryu"
+    ],
+    "answer": "Ryu"
+  },
+  {
+    "type": "romaji-to-hiragana",
+    "prompt": "pu",
+    "options": [
+      "ぎゃ",
+      "ぷ",
+      "ぶ",
+      "び"
+    ],
+    "answer": "ぷ"
+  },
+  {
+    "type": "hiragana-to-romaji",
+    "prompt": "し",
+    "options": [
+      "Kyo",
+      "Pi",
+      "Shi",
+      "Re"
+    ],
+    "answer": "Shi"
+  },
+  {
+    "type": "romaji-to-hiragana",
+    "prompt": "da",
+    "options": [
+      "しょ",
+      "じ",
+      "だ",
+      "よ"
+    ],
+    "answer": "だ"
+  },
+  {
+    "type": "hiragana-to-romaji",
+    "prompt": "みゅ",
+    "options": [
+      "Pa",
+      "Myu",
+      "Te",
+      "Bo"
+    ],
+    "answer": "Myu"
+  },
+  {
+    "type": "romaji-to-hiragana",
+    "prompt": "ri",
+    "options": [
+      "こ",
+      "じゅ",
+      "ぴ",
+      "り"
+    ],
+    "answer": "り"
+  },
+  {
+    "type": "hiragana-to-romaji",
+    "prompt": "ぎゃ",
+    "options": [
+      "Rya",
+      "Gya",
+      "Ni",
+      "Go"
+    ],
+    "answer": "Gya"
+  },
+  {
+    "type": "romaji-to-hiragana",
+    "prompt": "ni",
+    "options": [
+      "しゅ",
+      "わ",
+      "に",
+      "げ"
+    ],
+    "answer": "に"
+  },
+  {
+    "type": "hiragana-to-romaji",
+    "prompt": "が",
+    "options": [
+      "He",
+      "I",
+      "Ga",
+      "Go"
+    ],
+    "answer": "Ga"
+  },
+  {
+    "type": "romaji-to-hiragana",
+    "prompt": "chi",
+    "options": [
+      "は",
+      "ち",
+      "びゃ",
+      "お"
+    ],
+    "answer": "ち"
+  },
+  {
+    "type": "hiragana-to-romaji",
+    "prompt": "ぺ",
+    "options": [
+      "Pe",
+      "Su",
+      "O",
+      "Ku"
+    ],
+    "answer": "Pe"
+  },
+  {
+    "type": "romaji-to-hiragana",
+    "prompt": "sho",
+    "options": [
+      "しょ",
+      "じょ",
+      "か",
+      "ぴ"
+    ],
+    "answer": "しょ"
+  },
+  {
+    "type": "hiragana-to-romaji",
+    "prompt": "め",
+    "options": [
+      "Ku",
+      "Byo",
+      "Bi",
+      "Me"
+    ],
+    "answer": "Me"
+  },
+  {
+    "type": "romaji-to-hiragana",
+    "prompt": "bu",
+    "options": [
+      "ぽ",
+      "ぶ",
+      "る",
+      "ぴ"
+    ],
+    "answer": "ぶ"
+  },
+  {
+    "type": "hiragana-to-romaji",
+    "prompt": "ぢ",
+    "options": [
+      "Be",
+      "To",
+      "Ne",
+      "Ji"
+    ],
+    "answer": "Ji"
+  },
+  {
+    "type": "romaji-to-hiragana",
+    "prompt": "jo",
+    "options": [
+      "ふ",
+      "さ",
+      "ぴょ",
+      "じょ"
+    ],
+    "answer": "じょ"
+  },
+  {
+    "type": "hiragana-to-romaji",
+    "prompt": "る",
+    "options": [
+      "Ke",
+      "Ru",
+      "Ka",
+      "Pe"
+    ],
+    "answer": "Ru"
+  },
+  {
+    "type": "romaji-to-hiragana",
+    "prompt": "sa",
+    "options": [
+      "ふ",
+      "しゅ",
+      "さ",
+      "つ"
+    ],
+    "answer": "さ"
   },
   {
     "type": "hiragana-to-romaji",
     "prompt": "ね",
-    "options": ["Ne", "Nu", "No", "Ni"],
+    "options": [
+      "Rya",
+      "Bi",
+      "Ku",
+      "Ne"
+    ],
     "answer": "Ne"
+  },
+  {
+    "type": "romaji-to-hiragana",
+    "prompt": "ha",
+    "options": [
+      "ぷ",
+      "へ",
+      "は",
+      "しゃ"
+    ],
+    "answer": "は"
+  },
+  {
+    "type": "hiragana-to-romaji",
+    "prompt": "ふ",
+    "options": [
+      "Zu",
+      "Fu",
+      "Pya",
+      "De"
+    ],
+    "answer": "Fu"
+  },
+  {
+    "type": "romaji-to-hiragana",
+    "prompt": "no",
+    "options": [
+      "ちゃ",
+      "の",
+      "りゃ",
+      "お"
+    ],
+    "answer": "の"
+  },
+  {
+    "type": "hiragana-to-romaji",
+    "prompt": "ん",
+    "options": [
+      "Za",
+      "Go",
+      "Na",
+      "N"
+    ],
+    "answer": "N"
+  },
+  {
+    "type": "romaji-to-hiragana",
+    "prompt": "wo",
+    "options": [
+      "そ",
+      "を",
+      "ま",
+      "い"
+    ],
+    "answer": "を"
+  },
+  {
+    "type": "hiragana-to-romaji",
+    "prompt": "きゅ",
+    "options": [
+      "Pyo",
+      "Re",
+      "Kyu",
+      "Gya"
+    ],
+    "answer": "Kyu"
+  },
+  {
+    "type": "romaji-to-hiragana",
+    "prompt": "myo",
+    "options": [
+      "みょ",
+      "しゅ",
+      "ま",
+      "ぴょ"
+    ],
+    "answer": "みょ"
+  },
+  {
+    "type": "hiragana-to-romaji",
+    "prompt": "え",
+    "options": [
+      "Bo",
+      "E",
+      "Zo",
+      "Ju"
+    ],
+    "answer": "E"
+  },
+  {
+    "type": "romaji-to-hiragana",
+    "prompt": "i",
+    "options": [
+      "い",
+      "め",
+      "し",
+      "ぽ"
+    ],
+    "answer": "い"
+  },
+  {
+    "type": "hiragana-to-romaji",
+    "prompt": "ひ",
+    "options": [
+      "Mo",
+      "Byo",
+      "Ho",
+      "Hi"
+    ],
+    "answer": "Hi"
+  },
+  {
+    "type": "romaji-to-hiragana",
+    "prompt": "nyu",
+    "options": [
+      "か",
+      "にゅ",
+      "ゆ",
+      "しゃ"
+    ],
+    "answer": "にゅ"
   }
 ]


### PR DESCRIPTION
## Summary
- generate a comprehensive hiragana lesson
- include all basic, dakuten, and combination characters
- alternate question formats between hiragana→romaji and romaji→hiragana

## Testing
- `node generate_lessons.js` (script used to create data, not committed)


------
https://chatgpt.com/codex/tasks/task_e_68853810f264833182929f32e0148eb3