### PR TITLE
Add quiz mode selection

### DIFF
--- a/css/learn_japanese.css
+++ b/css/learn_japanese.css
@@ -107,3 +107,24 @@
   border: 1px solid rgba(255, 255, 255, 0.1);
   transition: all 0.3s ease;
 }
+
+.mode-buttons {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 2rem 0;
+}
+
+.mode-buttons button {
+  padding: 1rem;
+  font-size: 1.1rem;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.08);
+  color: white;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  transition: all 0.2s ease;
+}
+
+.mode-buttons button:hover {
+  background: rgba(255, 255, 255, 0.15);
+}

--- a/js/quiz.js
+++ b/js/quiz.js
@@ -1,48 +1,121 @@
-function renderQuestion(q) {
-  const container = document.getElementById("lessonView");
-  container.innerHTML = "";
+function shuffle(arr) {
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+  return arr;
+}
 
-  const promptEl = document.createElement("div");
-  promptEl.className = "quiz-prompt";
+let currentLessonData = null;
+let currentQuestions = [];
+let currentQuestionIndex = 0;
+let quizCallback = null;
+
+function startLesson(id) {
+  fetch(`data/lessons/${id}.json`)
+    .then(res => res.json())
+    .then(questions => {
+      currentLessonData = { questions };
+      document.getElementById('lessonsView').style.display = 'none';
+      document.getElementById('lessonView').style.display = 'flex';
+      showModeSelection(currentLessonData);
+    });
+}
+
+function showModeSelection(lessonData) {
+  currentLessonData = lessonData;
+  const view = document.getElementById('lessonView');
+  view.innerHTML = `
+    <h2>Select Quiz Mode</h2>
+    <div class="mode-buttons">
+      <button onclick="startQuiz('5')">5 Questions (Random)</button>
+      <button onclick="startQuiz('10')">10 Questions (Random)</button>
+      <button onclick="startQuiz('all')">All Questions (Ordered)</button>
+      <button onclick="startQuiz('endless')">Endless (Random)</button>
+    </div>
+  `;
+  view.style.display = 'flex';
+}
+
+function startQuiz(mode) {
+  let questions;
+  if (mode === '5') {
+    questions = shuffle([...currentLessonData.questions]).slice(0, 5);
+  } else if (mode === '10') {
+    questions = shuffle([...currentLessonData.questions]).slice(0, 10);
+  } else if (mode === 'all') {
+    questions = [...currentLessonData.questions];
+  } else if (mode === 'endless') {
+    questions = shuffle([...currentLessonData.questions]);
+    runEndlessQuiz(questions);
+    return;
+  }
+
+  runQuiz(questions);
+}
+
+function runQuiz(questions, onComplete) {
+  currentQuestions = questions;
+  currentQuestionIndex = 0;
+  quizCallback = onComplete || null;
+  renderQuestion(currentQuestions[currentQuestionIndex]);
+}
+
+function runEndlessQuiz(questions) {
+  if (questions.length === 0) {
+    questions = shuffle([...currentLessonData.questions]);
+  }
+  const [first, ...rest] = questions;
+  runQuiz([first], () => runEndlessQuiz(rest));
+}
+
+function renderQuestion(q) {
+  const container = document.getElementById('lessonView');
+  container.innerHTML = '';
+
+  const promptEl = document.createElement('div');
+  promptEl.className = 'quiz-prompt';
   promptEl.textContent = q.prompt;
   container.appendChild(promptEl);
 
-  const optionsContainer = document.createElement("div");
-  optionsContainer.className = "alphabet-grid"; // or reuse .kanji-grid
+  const optionsContainer = document.createElement('div');
+  optionsContainer.className = 'alphabet-grid';
   q.options.forEach(option => {
-    const btn = document.createElement("button");
-    btn.className = "btn";
+    const btn = document.createElement('button');
+    btn.className = 'btn';
     btn.textContent = option;
     btn.onclick = () => handleAnswer(option, q.answer);
     optionsContainer.appendChild(btn);
   });
 
   container.appendChild(optionsContainer);
-}
 
-let currentLessonData = null;
-let currentQuestionIndex = 0;
-
-function startLesson(id) {
-  fetch(`data/lessons/${id}.json`)
-    .then(res => res.json())
-    .then(questions => {
-      currentLessonData = questions;
-      currentQuestionIndex = 0;
-      document.getElementById('lessonsView').style.display = 'none';
-      document.getElementById('lessonView').style.display = 'flex';
-      renderQuestion(currentLessonData[currentQuestionIndex]);
-    });
+  const backBtn = document.createElement('button');
+  backBtn.className = 'back-button';
+  backBtn.textContent = 'Back to Mode Selection';
+  backBtn.onclick = () => showModeSelection(currentLessonData);
+  container.appendChild(backBtn);
 }
 
 function handleAnswer(option, answer) {
   if (option === answer) {
     currentQuestionIndex++;
-    if (currentLessonData && currentQuestionIndex < currentLessonData.length) {
-      renderQuestion(currentLessonData[currentQuestionIndex]);
+    if (currentQuestionIndex < currentQuestions.length) {
+      renderQuestion(currentQuestions[currentQuestionIndex]);
     } else {
-      const container = document.getElementById('lessonView');
-      container.innerHTML = "<div class='quiz-complete'>Lesson Complete!</div>";
+      const cb = quizCallback;
+      quizCallback = null;
+      if (cb) {
+        cb();
+      } else {
+        const container = document.getElementById('lessonView');
+        container.innerHTML = "<div class='quiz-complete'>Lesson Complete!</div>";
+        const backButton = document.createElement('button');
+        backButton.className = 'back-button';
+        backButton.textContent = 'Back to Mode Selection';
+        backButton.onclick = () => showModeSelection(currentLessonData);
+        container.appendChild(backButton);
+      }
     }
   } else {
     alert('Incorrect');


### PR DESCRIPTION
## Summary
- add mode selection menu before lessons begin
- support random, ordered, and endless quiz modes
- add a back button in quiz UI
- style new mode-selection buttons

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688539b416408331b5e9ae4c4b93986e