### PR TITLE
Add modal display for Kanji cards

### DIFF
--- a/css/kanji.css
+++ b/css/kanji.css
@@ -36,3 +36,61 @@
   color: white;
   font-size: 1rem;
 }
+
+.kanji-modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.75);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 9999;
+}
+
+.kanji-modal {
+  background-color: #1b1b1b;
+  border-radius: 12px;
+  padding: 24px;
+  color: #fff;
+  max-width: 320px;
+  width: 90%;
+  box-shadow: 0 0 20px rgba(0,0,0,0.5);
+  position: relative;
+  animation: fadeIn 0.3s ease-out;
+}
+
+.kanji-modal-close {
+  position: absolute;
+  top: 8px;
+  right: 14px;
+  font-size: 24px;
+  color: #aaa;
+  cursor: pointer;
+}
+
+.kanji-modal-content {
+  text-align: center;
+}
+
+.kanji-modal-char {
+  font-size: 4rem;
+  margin-bottom: 12px;
+}
+
+.kanji-modal-meaning {
+  font-size: 1.2rem;
+  margin-bottom: 16px;
+}
+
+.kanji-modal-section {
+  font-size: 1rem;
+  margin: 6px 0;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; transform: scale(0.95); }
+  to { opacity: 1; transform: scale(1); }
+}

--- a/js/main.js
+++ b/js/main.js
@@ -142,6 +142,9 @@ function showKanjiView() {
         const card = document.createElement('div');
         card.className = 'kanji-card';
         card.innerHTML = `<div class="kanji-char">${entry.kanji}</div><div class="kanji-meaning">${entry.meaning}</div>`;
+        card.addEventListener('click', () => {
+          createKanjiModal(entry);
+        });
         grid.appendChild(card);
       });
     });
@@ -150,4 +153,23 @@ function showKanjiView() {
 function hideKanjiView() {
   document.getElementById('kanjiView').classList.add('hidden');
   document.getElementById('mainMenu').classList.remove('hidden');
+}
+
+function createKanjiModal(entry) {
+  const modal = document.createElement('div');
+  modal.className = 'kanji-modal-overlay';
+
+  modal.innerHTML = `
+    <div class="kanji-modal">
+      <span class="kanji-modal-close" onclick="this.parentElement.parentElement.remove()">×</span>
+      <div class="kanji-modal-content">
+        <div class="kanji-modal-char">${entry.kanji}</div>
+        <div class="kanji-modal-meaning">${entry.meaning}</div>
+        <div class="kanji-modal-section"><strong>On'yomi:</strong> ${entry.on.join(', ')}</div>
+        <div class="kanji-modal-section"><strong>Kun'yomi:</strong> ${entry.kun.join(', ')}</div>
+      </div>
+    </div>
+  `;
+
+  document.body.appendChild(modal);
 }


### PR DESCRIPTION
## Summary
- allow Kanji cards to open a modal with full reading info
- style modal overlay and content

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_688638371bf08331a2d63c35930c5b4e