### PR TITLE
Add Kanji grid search

### DIFF
--- a/css/kanji.css
+++ b/css/kanji.css
@@ -37,6 +37,20 @@
   font-size: 1rem;
 }
 
+.kanji-search-input {
+  width: 90%;
+  max-width: 500px;
+  margin: 1rem auto;
+  padding: 0.75rem 1rem;
+  font-size: 1rem;
+  border-radius: 12px;
+  border: 1px solid #555;
+  background: rgba(255, 255, 255, 0.04);
+  color: white;
+  display: block;
+  backdrop-filter: blur(6px);
+}
+
 .kanji-modal-overlay {
   position: fixed;
   top: 0;

--- a/index.html
+++ b/index.html
@@ -50,6 +50,12 @@
   </div>
   <div id="kanjiView" class="page hidden">
     <h2>KANJI</h2>
+    <input 
+      type="text" 
+      id="kanjiSearchInput" 
+      placeholder="Search Kanji, reading, or meaning..."
+      class="kanji-search-input"
+    />
     <div id="kanjiGrid" class="kanji-grid"></div>
     <button class="back-button" onclick="hideKanjiView()">Back</button>
   </div>

--- a/js/main.js
+++ b/js/main.js
@@ -142,10 +142,33 @@ function showKanjiView() {
         const card = document.createElement('div');
         card.className = 'kanji-card';
         card.innerHTML = `<div class="kanji-char">${entry.kanji}</div><div class="kanji-meaning">${entry.meaning}</div>`;
+        card.dataset.kanji = entry.kanji;
+        card.dataset.meanings = entry.meaning;
+        card.dataset.readings = [...(entry.on || []), ...(entry.kun || [])].join(' ');
+        card.dataset.vocab = (entry.vocabulary || []).map(v => v.word + ' ' + v.kana + ' ' + v.meaning).join(' ');
         card.addEventListener('click', () => {
           createKanjiModal(entry);
         });
         grid.appendChild(card);
+      });
+
+      document.getElementById("kanjiSearchInput").addEventListener("input", function (e) {
+        const query = e.target.value.toLowerCase();
+
+        document.querySelectorAll(".kanji-card").forEach(card => {
+          const kanji = card.dataset.kanji || "";
+          const meanings = (card.dataset.meanings || "").toLowerCase();
+          const readings = (card.dataset.readings || "").toLowerCase();
+          const vocab = (card.dataset.vocab || "").toLowerCase();
+
+          const match =
+            kanji.includes(query) ||
+            meanings.includes(query) ||
+            readings.includes(query) ||
+            vocab.includes(query);
+
+          card.style.display = match ? "block" : "none";
+        });
       });
     });
 }


### PR DESCRIPTION
## Summary
- inject search input on the Kanji page
- style the search box
- populate dataset attributes for each kanji card and filter on input

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68863c190aec83319c56eab7b6fa9269