### PR TITLE
Add Katakana lesson navigation

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -238,6 +238,11 @@ function hideKanjiView() {
   document.getElementById('lessonsView')?.classList.remove('hidden');
 }
 
+function navigateTo(page, data = {}) {
+  sessionStorage.setItem('navigationData', JSON.stringify(data));
+  window.location.href = page;
+}
+
 function createKanjiModal(entry) {
   const modal = document.createElement('div');
   modal.className = 'kanji-modal-overlay';

--- a/pages/learn_japanese.html
+++ b/pages/learn_japanese.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Learn Japanese</title>
+  <link rel="stylesheet" href="../css/style.css">
+  <link rel="stylesheet" href="../css/learn_japanese.css">
+</head>
+<body>
+  <div class="main-menu" id="learnMenu">
+    <div class="header-title">Learn Japanese</div>
+    <button class="menu-button" onclick="navigateTo('lesson_mode.html', { lessonFile: 'data/lessons/hiragana_lesson1.json', lessonName: 'Hiragana: Lesson 1' })">Hiragana: Lesson 1</button>
+    <button class="menu-button" onclick="navigateTo('lesson_mode.html', { lessonFile: 'data/lessons/katakana_lesson1.json', lessonName: 'Katakana: Lesson 1' })">
+      Katakana: Lesson 1
+    </button>
+    <button class="menu-button back-button" onclick="window.history.back()">Back</button>
+  </div>
+  <script src="../js/main.js"></script>
+</body>
+</html>

--- a/pages/lesson_mode.html
+++ b/pages/lesson_mode.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Lesson Mode</title>
+  <link rel="stylesheet" href="../css/style.css">
+  <link rel="stylesheet" href="../css/learn_japanese.css">
+  <link rel="stylesheet" href="../css/quiz.css">
+</head>
+<body>
+  <div class="main-menu" id="lessonContainer">
+    <h2 id="lesson-title"></h2>
+    <div id="lessonView"></div>
+    <div id="quizView"></div>
+  </div>
+
+  <script src="../js/quiz.js"></script>
+  <script>
+  document.addEventListener("DOMContentLoaded", async () => {
+    const data = JSON.parse(sessionStorage.getItem("navigationData"));
+    const response = await fetch(data.lessonFile);
+    const questions = await response.json();
+    document.querySelector("#lesson-title").textContent = data.lessonName;
+    showModeSelection({ questions });
+  });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create learn_japanese page with lesson links
- create lesson_mode page to load lessons dynamically from `sessionStorage`
- add `navigateTo` helper in `js/main.js`

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_68867aa75a5c8331a6ebcd068b350208