### PR TITLE
Implement generic quiz logic

### DIFF
--- a/pages/hiragana-lesson1.html
+++ b/pages/hiragana-lesson1.html
@@ -10,7 +10,7 @@
       font-size: 3.5rem;
       margin-bottom: 2rem;
     }
-    .options {
+    #choices {
       display: flex;
       flex-direction: column;
       gap: 1rem;
@@ -28,14 +28,14 @@
 <body>
   <div class="container">
     <h1>Hiragana: Lesson 1</h1>
-    <div id="prompt" class="quiz-char">Loading...</div>
-    <div class="options"></div>
-    <div id="score" style="margin-top:1rem;"></div>
-      <a href="learn-japanese.html" class="button back-button">Back</a>
+    <div id="question" class="quiz-char">Loading...</div>
+    <div id="choices"></div>
+    <button id="next-btn" class="button" style="display:none;margin-top:1rem;">Next</button>
+    <a href="learn-japanese.html" class="button back-button">Back</a>
   </div>
-  <script src="../scripts/quiz.js"></script>
   <script>
-    initQuiz('../hiragana_lesson1.json');
+    var QUIZ_JSON = '../hiragana_lesson1.json';
   </script>
+  <script src="../scripts/quiz.js"></script>
 </body>
 </html>

--- a/pages/kanji-lesson1.html
+++ b/pages/kanji-lesson1.html
@@ -10,7 +10,7 @@
       font-size: 3.5rem;
       margin-bottom: 2rem;
     }
-    .options {
+    #choices {
       display: flex;
       flex-direction: column;
       gap: 1rem;
@@ -28,15 +28,14 @@
 <body>
   <div class="container">
     <h1>Kanji: Lesson 1</h1>
-    <div id="prompt" class="quiz-char">Loading...</div>
-    <div class="options"></div>
-    <button id="next" class="button" style="display:none;margin-top:1rem;">Next</button>
-    <div id="score" style="margin-top:1rem;"></div>
+    <div id="question" class="quiz-char">Loading...</div>
+    <div id="choices"></div>
+    <button id="next-btn" class="button" style="display:none;margin-top:1rem;">Next</button>
     <a href="learn-japanese.html" class="button back-button">Back</a>
   </div>
-  <script src="../scripts/quiz.js"></script>
   <script>
-    initQuiz('../data/kanji_lesson1.json');
+    var QUIZ_JSON = '../data/kanji_lesson1.json';
   </script>
+  <script src="../scripts/quiz.js"></script>
 </body>
 </html>

--- a/pages/katakana-lesson1.html
+++ b/pages/katakana-lesson1.html
@@ -10,7 +10,7 @@
       font-size: 3.5rem;
       margin-bottom: 2rem;
     }
-    .options {
+    #choices {
       display: flex;
       flex-direction: column;
       gap: 1rem;
@@ -28,15 +28,14 @@
 <body>
   <div class="container">
     <h1>Katakana: Lesson 1</h1>
-    <div id="prompt" class="quiz-char">Loading...</div>
-    <div class="options"></div>
-    <button id="next" class="button" style="display:none;margin-top:1rem;">Next</button>
-    <div id="score" style="margin-top:1rem;"></div>
+    <div id="question" class="quiz-char">Loading...</div>
+    <div id="choices"></div>
+    <button id="next-btn" class="button" style="display:none;margin-top:1rem;">Next</button>
     <a href="learn-japanese.html" class="button back-button">Back</a>
   </div>
-  <script src="../scripts/quiz.js"></script>
   <script>
-    initQuiz('../data/katakana_lesson1.json');
+    var QUIZ_JSON = '../data/katakana_lesson1.json';
   </script>
+  <script src="../scripts/quiz.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add reusable quiz script that loads quiz data from `QUIZ_JSON`
- update hiragana, katakana and kanji quiz pages to use new script and IDs

## Testing
- `node --check scripts/quiz.js`

------
https://chatgpt.com/codex/tasks/task_e_6886d7ee432883318a3971b6c5377641