### PR TITLE
Shuffle quiz questions on load

### DIFF
--- a/scripts/quiz.js
+++ b/scripts/quiz.js
@@ -1,8 +1,16 @@
 (function(){
+  function shuffle(arr){
+    for(let i = arr.length - 1; i > 0; i--){
+      const j = Math.floor(Math.random() * (i + 1));
+      [arr[i], arr[j]] = [arr[j], arr[i]];
+    }
+    return arr;
+  }
+
   async function start(){
     if(!window.QUIZ_JSON) return console.error('QUIZ_JSON not defined');
     const res = await fetch(QUIZ_JSON);
-    const questions = await res.json();
+    const questions = shuffle(await res.json());
     runQuiz(questions);
   }
 
@@ -25,13 +33,6 @@
       }
     });
 
-    function shuffle(arr){
-      for(let i=arr.length-1;i>0;i--){
-        const j = Math.floor(Math.random()*(i+1));
-        [arr[i],arr[j]] = [arr[j],arr[i]];
-      }
-      return arr;
-    }
 
     function renderQuestion(){
       const q = questions[index];


### PR DESCRIPTION
## Summary
- shuffle the question list once when loading JSON
- keep option shuffling per question as before

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688742913850833198d5d9f99e40f4e3