### PR TITLE
Fix quiz JSON detection for Hiragana Lesson 2

### DIFF
--- a/pages/hiragana-lesson2.html
+++ b/pages/hiragana-lesson2.html
@@ -25,7 +25,7 @@
     }
   </style>
   <script>
-    const QUIZ_JSON = '../data/hiragana_lesson2.json';
+    var QUIZ_JSON = '../data/hiragana_lesson2.json';
   </script>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- ensure QUIZ_JSON uses `var` so quiz.js can access it

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6887710788fc8331aa901b4d8b599027